### PR TITLE
Framework robustness improvement and new benchmark support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,5 @@ data/
 .idea/
 
 .DS_Store
+
+apps/collect-trace/scripts/*/*.sh

--- a/apps/miroflow-agent/benchmarks/common_benchmark.py
+++ b/apps/miroflow-agent/benchmarks/common_benchmark.py
@@ -295,6 +295,7 @@ class BenchmarkEvaluator(ABC):
                 if (
                     attempt_result["model_boxed_answer"]
                     and attempt_result["final_judge_result"] is None
+                    and task.ground_truth is not None
                 ):
                     print(f"    Verifying answer for attempt {attempt}...")
                     try:
@@ -378,13 +379,17 @@ class BenchmarkEvaluator(ABC):
                 result.final_judge_result = "PASS_AT_K_SUCCESS"
                 result.judge_type = "pass_at_k"
             else:
-                result.final_judge_result = "PASS_AT_K_FAILED"
+                if result.ground_truth is None:
+                    result.final_judge_result = "TEST_SET_MODE"
+                else:
+                    result.final_judge_result = "PASS_AT_K_FAILED"
                 result.judge_type = "pass_at_k"
 
             print(f"Task {task.task_id} completed with {len(result.attempts)} attempts")
-            print(
-                f"    Pass@{self.pass_at_k} result: {'✅ SUCCESS' if found_correct_answer else '❌ FAILED'}"
-            )
+            if result.ground_truth is not None:
+                print(
+                    f"    Pass@{self.pass_at_k} result: {'✅ SUCCESS' if found_correct_answer else '❌ FAILED'}"
+                )
 
         return result
 
@@ -509,9 +514,10 @@ class BenchmarkEvaluator(ABC):
             # Display task results
             print(f"\nTask {result.task_id}:")
             print(f"  Attempts: {len(result.attempts)}")
-            print(
-                f"  Pass@{self.pass_at_k}: {'✅ SUCCESS' if result.pass_at_k_success else '❌ FAILED'}"
-            )
+            if result.ground_truth is not None:
+                print(
+                    f"  Pass@{self.pass_at_k}: {'✅ SUCCESS' if result.pass_at_k_success else '❌ FAILED'}"
+                )
 
             print("  " + "=" * 50)
             print(f"  Reference: {result.ground_truth}")

--- a/apps/miroflow-agent/benchmarks/evaluators/eval_utils.py
+++ b/apps/miroflow-agent/benchmarks/evaluators/eval_utils.py
@@ -469,6 +469,9 @@ async def verify_answer_for_datasets(
     Returns a tuple of (result, judge_type).
     """
 
+    if predicted_answer == target:
+        return "CORRECT", "exact_match"
+
     # For gaia-validation, use gaia scorer
     if benchmark_name == "gaia-validation":
         result = await verify_answer_gaia(question, target, predicted_answer)

--- a/apps/miroflow-agent/benchmarks/evaluators/extract_futurex_results.py
+++ b/apps/miroflow-agent/benchmarks/evaluators/extract_futurex_results.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import json
+import os
+from collections import Counter, defaultdict
+from typing import Dict, List, Tuple
+
+
+def majority_vote(
+    preds: List[str], first_seen_order: Dict[str, int]
+) -> Tuple[str, Dict[str, int]]:
+    """
+    Compute the majority-vote prediction for a list of candidate predictions.
+
+    Tie-breaking rules (deterministic):
+      1) Highest frequency wins.
+      2) If there is a tie on frequency, choose the candidate that appeared earliest
+         across all runs (based on the provided first_seen_order index).
+      3) As a final guard (shouldn't be needed if first_seen_order is complete),
+         fall back to lexicographic order.
+
+    Returns:
+      (chosen_prediction, counts_dict)
+    """
+    counter = Counter(preds)
+    # Get the max vote count
+    max_count = max(counter.values())
+    # All candidates that share the max vote count
+    tied = [c for c, cnt in counter.items() if cnt == max_count]
+
+    if len(tied) == 1:
+        chosen = tied[0]
+    else:
+        # Prefer the one seen earliest globally
+        tied.sort(key=lambda x: (first_seen_order.get(x, float("inf")), x))
+        chosen = tied[0]
+
+    # Expose counts for optional debugging/inspection
+    return chosen, dict(counter)
+
+
+def discover_runs(results_dir: str) -> List[str]:
+    """
+    Discover subdirectories inside results_dir that potentially contain a
+    'benchmark_results.jsonl'. We don't strictly require the subdir name to
+    start with 'run_', but we sort the list to keep processing deterministic.
+    """
+    runs = []
+    for name in sorted(os.listdir(results_dir)):
+        path = os.path.join(results_dir, name)
+        if os.path.isdir(path):
+            fpath = os.path.join(path, "benchmark_results.jsonl")
+            if os.path.isfile(fpath):
+                runs.append(path)
+    return runs
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Aggregate multiple run_*/benchmark_results.jsonl files and produce a FutureX submission with majority voting."
+    )
+    parser.add_argument(
+        "results_dir",
+        help="Path to results dir containing run_*/benchmark_results.jsonl",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Output JSONL file path (default: <results_dir>/futurex_submission.jsonl)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    results_dir = os.path.abspath(args.results_dir)
+    if not os.path.isdir(results_dir):
+        raise FileNotFoundError(f"Results dir not found: {results_dir}")
+
+    output_file = (
+        os.path.abspath(args.output)
+        if args.output
+        else os.path.join(results_dir, "futurex_submission.jsonl")
+    )
+
+    # Maps task_id -> list of predictions collected across runs
+    preds_by_task: Dict[str, List[str]] = defaultdict(list)
+
+    # Track first-seen order index for each distinct prediction string across all runs.
+    # This enables deterministic tie-breaking.
+    first_seen_order: Dict[str, int] = {}
+    next_order_idx = 0
+
+    runs = discover_runs(results_dir)
+    if not runs:
+        raise FileNotFoundError(
+            f"No run directories with 'benchmark_results.jsonl' found under: {results_dir}"
+        )
+
+    total_lines = 0
+    used_lines = 0
+
+    # Read and aggregate predictions
+    for run_dir in runs:
+        fpath = os.path.join(run_dir, "benchmark_results.jsonl")
+        print(f"Reading: {fpath}")
+        with open(fpath, "r", encoding="utf-8") as fin:
+            for line in fin:
+                total_lines += 1
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    # Skip malformed JSON lines, but keep going
+                    continue
+
+                task_id = rec.get("task_id")
+                pred = rec.get("model_boxed_answer")
+
+                # Only accept non-empty strings; coerce to str for safety
+                if task_id and pred is not None and str(pred).strip():
+                    pred_str = str(pred).strip()
+                    preds_by_task[task_id].append(pred_str)
+                    if pred_str not in first_seen_order:
+                        first_seen_order[pred_str] = next_order_idx
+                        next_order_idx += 1
+                    used_lines += 1
+
+    # Write submission JSONL
+    # We sort task_ids to keep output reproducible.
+    num_tasks = 0
+    with open(output_file, "w", encoding="utf-8") as out:
+        for task_id in sorted(preds_by_task.keys()):
+            voted_pred, _counts = majority_vote(
+                preds_by_task[task_id], first_seen_order
+            )
+            out.write(
+                json.dumps(
+                    {"id": task_id, "prediction": voted_pred}, ensure_ascii=False
+                )
+                + "\n"
+            )
+            num_tasks += 1
+
+    # Optional: small summary to stdout
+    print(f"Collected from {len(runs)} run(s).")
+    print(f"Read {total_lines} line(s), accepted {used_lines} record(s).")
+    print(f"Aggregated {num_tasks} unique task_id(s).")
+    print(f"✅ Submission saved to {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/miroflow-agent/conf/benchmark/browsecomp.yaml
+++ b/apps/miroflow-agent/conf/benchmark/browsecomp.yaml
@@ -8,7 +8,8 @@ name: "browsecomp"
 data:
   data_dir: "../../data/browsecomp"
 
-
 execution:
   max_tasks: null  # null means no limit
   max_concurrent: 5
+  pass_at_k: 1
+  format_error_retry_limit: 3

--- a/apps/miroflow-agent/conf/benchmark/browsecomp_zh.yaml
+++ b/apps/miroflow-agent/conf/benchmark/browsecomp_zh.yaml
@@ -8,7 +8,8 @@ name: "browsecomp_zh"
 data:
   data_dir: "../../data/browsecomp_zh"
 
-
 execution:
   max_tasks: null  # null means no limit
   max_concurrent: 5
+  pass_at_k: 1
+  format_error_retry_limit: 3

--- a/apps/miroflow-agent/conf/benchmark/frames.yaml
+++ b/apps/miroflow-agent/conf/benchmark/frames.yaml
@@ -8,7 +8,8 @@ name: "frames"
 data:
   data_dir: "../../data/frames"
 
-
 execution:
   max_tasks: null  # null means no limit
   max_concurrent: 5
+  pass_at_k: 1
+  format_error_retry_limit: 3

--- a/apps/miroflow-agent/conf/benchmark/futurex.yaml
+++ b/apps/miroflow-agent/conf/benchmark/futurex.yaml
@@ -1,0 +1,15 @@
+# conf/benchmark/futurex.yaml
+defaults:
+  - default
+  - _self_
+
+name: "futurex"
+
+data:
+  data_dir: "../../data/futurex"
+
+execution:
+  max_tasks: null  # null means no limit
+  max_concurrent: 5
+  pass_at_k: 1
+  format_error_retry_limit: 3

--- a/apps/miroflow-agent/conf/benchmark/gaia-validation-text-103.yaml
+++ b/apps/miroflow-agent/conf/benchmark/gaia-validation-text-103.yaml
@@ -11,4 +11,5 @@ data:
 execution:
   max_tasks: null  # null means no limit
   max_concurrent: 5
+  pass_at_k: 1
   format_error_retry_limit: 3

--- a/apps/miroflow-agent/conf/benchmark/hle-text-500.yaml
+++ b/apps/miroflow-agent/conf/benchmark/hle-text-500.yaml
@@ -8,7 +8,8 @@ name: "hle-text-500"
 data:
   data_dir: "../../data/hle-text-500"
 
-
 execution:
   max_tasks: null  # null means no limit
   max_concurrent: 5
+  pass_at_k: 1
+  format_error_retry_limit: 3

--- a/apps/miroflow-agent/conf/benchmark/hle.yaml
+++ b/apps/miroflow-agent/conf/benchmark/hle.yaml
@@ -8,7 +8,8 @@ name: "hle"
 data:
   data_dir: "../../data/hle"
 
-
 execution:
   max_tasks: null  # null means no limit
   max_concurrent: 5
+  pass_at_k: 1
+  format_error_retry_limit: 3

--- a/apps/miroflow-agent/conf/benchmark/webwalkerqa.yaml
+++ b/apps/miroflow-agent/conf/benchmark/webwalkerqa.yaml
@@ -8,7 +8,8 @@ name: "webwalkerqa"
 data:
   data_dir: "../../data/webwalkerqa"
 
-
 execution:
   max_tasks: null  # null means no limit
   max_concurrent: 5
+  pass_at_k: 1
+  format_error_retry_limit: 3

--- a/apps/miroflow-agent/pyproject.toml
+++ b/apps/miroflow-agent/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "tiktoken>=0.9.0",
     "aiohttp",
     "colorama>=0.4.6",
+    "json-repair>=0.49.0"
 ]
 
 [build-system]

--- a/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_browsecomp.sh
+++ b/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_browsecomp.sh
@@ -36,6 +36,7 @@ for i in $(seq 1 $NUM_RUNS); do
     (
         uv run python benchmarks/common_benchmark.py \
             benchmark=$BENCHMARK_NAME \
+            benchmark.data.metadata_file="standardized_data.jsonl" \
             llm=qwen3-32b \
             llm.provider=$LLM_PROVIDER \
             llm.model_name=$LLM_MODEL \

--- a/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_browsecomp_zh.sh
+++ b/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_browsecomp_zh.sh
@@ -36,6 +36,7 @@ for i in $(seq 1 $NUM_RUNS); do
     (
         uv run python benchmarks/common_benchmark.py \
             benchmark=$BENCHMARK_NAME \
+            benchmark.data.metadata_file="standardized_data.jsonl" \
             llm=qwen3-32b \
             llm.provider=$LLM_PROVIDER \
             llm.model_name=$LLM_MODEL \

--- a/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_frames.sh
+++ b/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_frames.sh
@@ -36,6 +36,7 @@ for i in $(seq 1 $NUM_RUNS); do
     (
         uv run python benchmarks/common_benchmark.py \
             benchmark=$BENCHMARK_NAME \
+            benchmark.data.metadata_file="standardized_data.jsonl" \
             llm=qwen3-32b \
             llm.provider=$LLM_PROVIDER \
             llm.model_name=$LLM_MODEL \

--- a/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_futurex.sh
+++ b/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_futurex.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Parse environment variables, use defaults if not set
+LLM_MODEL=${LLM_MODEL:-"MiroThinker-Models"}
+BASE_URL=${BASE_URL:-"https://your-api.com/v1"}
+
+# Configuration parameters
+NUM_RUNS=${NUM_RUNS:-8}
+BENCHMARK_NAME="futurex"
+LLM_PROVIDER=${LLM_PROVIDER:-"qwen"}
+AGENT_SET=${AGENT_SET:-"evaluation"}
+MAX_CONTEXT_LENGTH=${MAX_CONTEXT_LENGTH:-40960}
+MAX_CONCURRENT=${MAX_CONCURRENT:-10}
+PASS_AT_K=${PASS_AT_K:-1}
+
+# Set results directory
+RESULTS_DIR="../../logs/${BENCHMARK_NAME}/$(date +%m%d)/${LLM_PROVIDER}_${LLM_MODEL}_${AGENT_SET}"
+
+echo "Starting $NUM_RUNS runs of the evaluation..."
+echo "Results will be saved in: $RESULTS_DIR"
+
+# Create results directory
+mkdir -p "$RESULTS_DIR"
+
+# Launch all parallel tasks
+for i in $(seq 1 $NUM_RUNS); do
+    echo "=========================================="
+    echo "Launching experiment $i/$NUM_RUNS"
+    echo "Output log: please view $RESULTS_DIR/run_${i}_output.log"
+    echo "=========================================="
+    
+    # Set specific identifier for this run
+    RUN_ID="run_$i"
+    
+    # Run experiment (background execution)
+    (
+        uv run python benchmarks/common_benchmark.py \
+            benchmark=$BENCHMARK_NAME \
+            benchmark.data.metadata_file="standardized_data_250827_250902.jsonl" \
+            llm=qwen3-32b \
+            llm.provider=$LLM_PROVIDER \
+            llm.model_name=$LLM_MODEL \
+            llm.openai_base_url=$BASE_URL \
+            llm.async_client=true \
+            llm.temperature=0.3 \
+            llm.max_context_length=$MAX_CONTEXT_LENGTH \
+            benchmark.execution.max_tasks=null \
+            benchmark.execution.max_concurrent=$MAX_CONCURRENT \
+            benchmark.execution.pass_at_k=$PASS_AT_K \
+            benchmark.data.data_dir=../../data/futurex \
+            agent=$AGENT_SET \
+            hydra.run.dir=${RESULTS_DIR}/$RUN_ID \
+            2>&1 | tee "$RESULTS_DIR/${RUN_ID}_output.log" 
+        
+        # Check if run was successful
+        if [ $? -eq 0 ]; then
+            echo "Run $i completed successfully"
+            RESULT_FILE=$(find "${RESULTS_DIR}/$RUN_ID" -name "*accuracy.txt" 2>/dev/null | head -1)
+            if [ -f "$RESULT_FILE" ]; then
+                echo "Results saved to $RESULT_FILE"
+            else
+                echo "Warning: Result file not found for run $i"
+            fi
+        else
+            echo "Run $i failed!"
+        fi
+    ) &
+    
+    # Small delay between launches to avoid simultaneous requests
+    sleep 2
+done
+
+echo "All $NUM_RUNS runs have been launched in parallel"
+echo "Waiting for all runs to complete..."
+
+# Wait for all background tasks to complete
+wait
+
+echo "=========================================="
+echo "All $NUM_RUNS runs completed!"
+echo "=========================================="
+
+# Calculate average scores
+# echo "Calculating average scores..."
+# uv run python benchmarks/evaluators/calculate_average_score.py "$RESULTS_DIR"
+echo "Extracting predictions and formatting for FutureX submission..."
+uv run python benchmarks/evaluators/extract_futurex_results.py "$RESULTS_DIR"
+
+# Check status and provide user-friendly message
+if [ $? -eq 0 ]; then
+    echo "✅ Submission file generated: $RESULTS_DIR/futurex_submission.jsonl"
+    echo "You can now upload this file to the FutureX test server."
+else
+    echo "❌ Failed to generate submission file. Please check the logs for details."
+fi
+
+echo "=========================================="
+echo "Multiple runs evaluation completed!"
+echo "Check results in: $RESULTS_DIR"
+echo "Check individual run logs: $RESULTS_DIR/run_*_output.log"
+echo "==========================================" 

--- a/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_gaia-validation-text-103.sh
+++ b/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_gaia-validation-text-103.sh
@@ -36,6 +36,7 @@ for i in $(seq 1 $NUM_RUNS); do
     (
         uv run python benchmarks/common_benchmark.py \
             benchmark=$BENCHMARK_NAME \
+            benchmark.data.metadata_file="standardized_data.jsonl" \
             llm=qwen3-32b \
             llm.provider=$LLM_PROVIDER \
             llm.model_name=$LLM_MODEL \

--- a/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_gaia-validation.sh
+++ b/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_gaia-validation.sh
@@ -36,6 +36,7 @@ for i in $(seq 1 $NUM_RUNS); do
     (
         uv run python benchmarks/common_benchmark.py \
             benchmark=$BENCHMARK_NAME \
+            benchmark.data.metadata_file="standardized_data.jsonl" \
             llm=qwen3-32b \
             llm.provider=$LLM_PROVIDER \
             llm.model_name=$LLM_MODEL \

--- a/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_hle-text-500.sh
+++ b/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_hle-text-500.sh
@@ -36,6 +36,7 @@ for i in $(seq 1 $NUM_RUNS); do
     (
         uv run python benchmarks/common_benchmark.py \
             benchmark=$BENCHMARK_NAME \
+            benchmark.data.metadata_file="standardized_data.jsonl" \
             llm=qwen3-32b \
             llm.provider=$LLM_PROVIDER \
             llm.model_name=$LLM_MODEL \

--- a/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_hle.sh
+++ b/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_hle.sh
@@ -36,6 +36,7 @@ for i in $(seq 1 $NUM_RUNS); do
     (
         uv run python benchmarks/common_benchmark.py \
             benchmark=$BENCHMARK_NAME \
+            benchmark.data.metadata_file="standardized_data.jsonl" \
             llm=qwen3-32b \
             llm.provider=$LLM_PROVIDER \
             llm.model_name=$LLM_MODEL \

--- a/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_webwalkerqa.sh
+++ b/apps/miroflow-agent/scripts/run_evaluate_multiple_runs_webwalkerqa.sh
@@ -36,6 +36,7 @@ for i in $(seq 1 $NUM_RUNS); do
     (
         uv run python benchmarks/common_benchmark.py \
             benchmark=$BENCHMARK_NAME \
+            benchmark.data.metadata_file="standardized_data.jsonl" \
             llm=qwen3-32b \
             llm.provider=$LLM_PROVIDER \
             llm.model_name=$LLM_MODEL \

--- a/apps/miroflow-agent/src/core/orchestrator.py
+++ b/apps/miroflow-agent/src/core/orchestrator.py
@@ -449,6 +449,9 @@ class Orchestrator:
 
         self.task_log.end_sub_agent_session(sub_agent_name)
 
+        # Remove thinking content in tool response
+        final_answer_text = final_answer_text.split("</think>")[-1].strip()
+
         # Return final answer instead of conversation log, so main agent can use it directly
         return final_answer_text
 

--- a/apps/miroflow-agent/src/io/input_handler.py
+++ b/apps/miroflow-agent/src/io/input_handler.py
@@ -201,7 +201,7 @@ def process_input(task_description, task_file_name):
                 f"\nWarning: There was an error processing the file '{task_file_name}'."
             )
 
-    # output format requiremnt
+    # output format requirement
     updated_task_description += "\nYou should follow the format instruction in the requestion strictly and wrap the final answer in \\boxed{}."
     initial_user_content += updated_task_description
 

--- a/apps/miroflow-agent/src/utils/parsing_utils.py
+++ b/apps/miroflow-agent/src/utils/parsing_utils.py
@@ -32,14 +32,14 @@ def safe_json_loads(arguments_str: str) -> dict:
     try:
         return json.loads(arguments_str)
     except json.JSONDecodeError:
-        print(f"Warning: Unable to parse JSON: {arguments_str}")
+        logger.warning(f"Unable to parse JSON: {arguments_str}")
 
     # Step 2: Try json_repair to fix common issues
     try:
         repaired = repair_json(arguments_str, ensure_ascii=False)
         return json.loads(repaired)
     except Exception:
-        print("Info: json_repair also failed, trying fallback fixes.")
+        logger.info("json_repair also failed, trying fallback fixes.")
 
     # Step 3: Apply simple string replacements as a last resort
     try:

--- a/apps/miroflow-agent/src/utils/parsing_utils.py
+++ b/apps/miroflow-agent/src/utils/parsing_utils.py
@@ -51,7 +51,7 @@ def safe_json_loads(arguments_str: str) -> dict:
         )
         return json.loads(fixed)
     except json.JSONDecodeError:
-        print(f"Error: Still unable to parse JSON after all attempts: {arguments_str}")
+        logger.error(f"Error: Still unable to parse JSON after all attempts: {arguments_str}")
 
     # Step 4: Give up and return error information
     return {

--- a/apps/miroflow-agent/src/utils/parsing_utils.py
+++ b/apps/miroflow-agent/src/utils/parsing_utils.py
@@ -15,8 +15,49 @@
 import json
 import logging
 import re
+from json_repair import repair_json
 
 logger = logging.getLogger("miroflow_agent")
+
+
+def safe_json_loads(arguments_str: str) -> dict:
+    """
+    Safely parse a JSON string with multiple fallbacks:
+    1. Try standard json.loads()
+    2. If it fails, try json_repair
+    3. If it still fails, apply simple rule-based fixes
+    4. If all attempts fail, return an error object
+    """
+    # Step 1: Try standard JSON parsing
+    try:
+        return json.loads(arguments_str)
+    except json.JSONDecodeError:
+        print(f"Warning: Unable to parse JSON: {arguments_str}")
+
+    # Step 2: Try json_repair to fix common issues
+    try:
+        repaired = repair_json(arguments_str, ensure_ascii=False)
+        return json.loads(repaired)
+    except Exception:
+        print("Info: json_repair also failed, trying fallback fixes.")
+
+    # Step 3: Apply simple string replacements as a last resort
+    try:
+        fixed = (
+            arguments_str.replace("'", '"')
+            .replace("None", "null")
+            .replace("True", "true")
+            .replace("False", "false")
+        )
+        return json.loads(fixed)
+    except json.JSONDecodeError:
+        print(f"Error: Still unable to parse JSON after all attempts: {arguments_str}")
+
+    # Step 4: Give up and return error information
+    return {
+        "error": "Failed to parse arguments",
+        "raw": arguments_str,
+    }
 
 
 def parse_llm_response_for_tool_calls(llm_response_content_text):
@@ -32,34 +73,7 @@ def parse_llm_response_for_tool_calls(llm_response_content_text):
             if item.get("type") == "function_call":
                 server_name, tool_name = item.get("name").rsplit("-", maxsplit=1)
                 arguments_str = item.get("arguments")
-                try:
-                    # Try to handle possible newlines and escape characters
-                    arguments = json.loads(arguments_str)
-                except json.JSONDecodeError:
-                    print(
-                        f"Warning: Unable to parse tool arguments JSON: {arguments_str}"
-                    )
-                    # Try more lenient parsing or log error
-                    try:
-                        # Try to replace some common error formats, such as Python dict strings
-                        arguments_str_fixed = (
-                            arguments_str.replace("'", '"')
-                            .replace("None", "null")
-                            .replace("True", "true")
-                            .replace("False", "false")
-                        )
-                        arguments = json.loads(arguments_str_fixed)
-                        print(
-                            "Info: Successfully parsed arguments after attempting to fix."
-                        )
-                    except json.JSONDecodeError:
-                        print(
-                            f"Error: Still unable to parse tool arguments JSON after fixing: {arguments_str}"
-                        )
-                        arguments = {
-                            "error": "Failed to parse arguments",
-                            "raw": arguments_str,
-                        }
+                arguments = safe_json_loads(arguments_str)
                 tool_calls.append(
                     dict(
                         server_name=server_name,
@@ -132,31 +146,7 @@ def parse_llm_response_for_tool_calls(llm_response_content_text):
         arguments_str = match[2].strip()
 
         # Parse JSON string to dictionary
-        try:
-            # Try to handle possible newlines and escape characters
-            arguments = json.loads(arguments_str)
-        except json.JSONDecodeError:
-            logger.info(
-                f"Warning: Unable to parse tool arguments JSON: {arguments_str}"
-            )
-            # Try more lenient parsing or log error
-            try:
-                # Try to replace some common error formats, such as Python dict strings
-                arguments_str_fixed = (
-                    arguments_str.replace("'", '"')
-                    .replace("None", "null")
-                    .replace("True", "true")
-                    .replace("False", "false")
-                )
-                arguments = json.loads(arguments_str_fixed)
-                logger.info(
-                    "Info: Successfully parsed arguments after attempting to fix."
-                )
-            except json.JSONDecodeError:
-                logger.info(
-                    f"Error: Still unable to parse tool arguments JSON after fixing: {arguments_str}"
-                )
-                arguments = {"error": "Failed to parse arguments", "raw": arguments_str}
+        arguments = safe_json_loads(arguments_str)
 
         tool_calls.append(
             {

--- a/libs/miroflow-tools/src/miroflow_tools/manager.py
+++ b/libs/miroflow-tools/src/miroflow_tools/manager.py
@@ -205,7 +205,7 @@ class ToolManager(ToolManagerProtocol):
 
         return all_servers_for_prompt
 
-    @with_timeout(300)
+    @with_timeout(1200)
     async def execute_tool_call(self, server_name, tool_name, arguments) -> Any:
         """
         Execute a single tool call.

--- a/libs/miroflow-tools/src/miroflow_tools/mcp_servers/reasoning_mcp_server_os.py
+++ b/libs/miroflow-tools/src/miroflow_tools/mcp_servers/reasoning_mcp_server_os.py
@@ -30,7 +30,7 @@ REASONING_MODEL_NAME = os.environ.get("REASONING_MODEL_NAME")
 mcp = FastMCP("reasoning-mcp-server-os")
 
 # Retry configuration
-MAX_RETRIES = 5
+MAX_RETRIES = 10
 BACKOFF_BASE = 1.0  # initial backoff in seconds
 BACKOFF_MAX = 30.0  # maximum backoff in seconds
 
@@ -40,7 +40,7 @@ def post_with_retry(url, json, headers):
     Returns response object if success, otherwise None."""
     for attempt in range(1, MAX_RETRIES + 1):
         try:
-            resp = requests.post(url, json=json, headers=headers, timeout=60)
+            resp = requests.post(url, json=json, headers=headers, timeout=600)
             if resp.status_code == 200:
                 return resp
             else:
@@ -58,7 +58,7 @@ def post_with_retry(url, json, headers):
             logger.info(f"Retrying in {sleep_time:.1f}s...")
             time.sleep(sleep_time)
 
-    logger.error(f"All {MAX_RETRIES} retries failed for {url}")
+    logger.warning(f"All {MAX_RETRIES} retries failed for {url}")
     return None
 
 

--- a/libs/miroflow-tools/src/miroflow_tools/mcp_servers/reasoning_mcp_server_os.py
+++ b/libs/miroflow-tools/src/miroflow_tools/mcp_servers/reasoning_mcp_server_os.py
@@ -43,6 +43,8 @@ async def reasoning(question: str) -> str:
     payload = {
         "model": REASONING_MODEL_NAME,
         "messages": [{"role": "user", "content": question}],
+        "temperature": 0.6,
+        "top_p": 0.95,
     }
     headers = {
         "Authorization": f"Bearer {REASONING_API_KEY}",

--- a/libs/miroflow-tools/src/miroflow_tools/mcp_servers/reasoning_mcp_server_os.py
+++ b/libs/miroflow-tools/src/miroflow_tools/mcp_servers/reasoning_mcp_server_os.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import os
+import time
+import random
 
 from fastmcp import FastMCP
 import requests
@@ -26,6 +28,38 @@ REASONING_MODEL_NAME = os.environ.get("REASONING_MODEL_NAME")
 
 # Initialize FastMCP server
 mcp = FastMCP("reasoning-mcp-server-os")
+
+# Retry configuration
+MAX_RETRIES = 5
+BACKOFF_BASE = 1.0  # initial backoff in seconds
+BACKOFF_MAX = 30.0  # maximum backoff in seconds
+
+
+def post_with_retry(url, json, headers):
+    """Send POST request with retry and exponential backoff.
+    Returns response object if success, otherwise None."""
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            resp = requests.post(url, json=json, headers=headers, timeout=60)
+            if resp.status_code == 200:
+                return resp
+            else:
+                logger.warning(
+                    f"HTTP {resp.status_code} on attempt {attempt}: {resp.text[:200]}"
+                )
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"Request failed on attempt {attempt}: {e}")
+
+        # Backoff before next retry
+        if attempt < MAX_RETRIES:
+            sleep_time = min(BACKOFF_BASE * (2 ** (attempt - 1)), BACKOFF_MAX)
+            # Add jitter to avoid thundering herd
+            sleep_time *= 0.8 + 0.4 * random.random()
+            logger.info(f"Retrying in {sleep_time:.1f}s...")
+            time.sleep(sleep_time)
+
+    logger.error(f"All {MAX_RETRIES} retries failed for {url}")
+    return None
 
 
 @mcp.tool()
@@ -51,7 +85,10 @@ async def reasoning(question: str) -> str:
         "Content-Type": "application/json",
     }
 
-    response = requests.post(REASONING_BASE_URL, json=payload, headers=headers)
+    response = post_with_retry(REASONING_BASE_URL, json=payload, headers=headers)
+    if response is None:
+        return "Reasoning service unavailable. Please try again later."
+
     json_response = response.json()
     try:
         content = json_response["choices"][0]["message"]["content"]


### PR DESCRIPTION
1. **Added exact match fallback in `verify_answer_for_datasets`**
   String match results no longer need to be sent to LLM-as-judge. This helps avoid misjudgments and saves some API costs.

2. **Supported the new FutureX benchmark**
   Added related configs and answer extraction scripts.

3. **Improved handling of test sets (no ground truth) in `common_benchmark.py`**
   Prevents such questions from being sent to LLM-as-judge for meaningless evaluation. Also added differentiation in `final_judge_result`.

4. **Made default parameters explicit in YAML and shell scripts**
   Explicitly specifying default values may improve user experience, but has no impact on test performance.

5. **Fixed performance issue with thinking model as browse agent**
   Previously, think content was returned as the tool call result, causing performance degradation. Removing this part improves performance.

6. **Added support for `json_repair` in `parsing_utils.py`**
   In our current use cases, more than 99% of unparseable JSONs caused by model prediction errors can be fixed by this library.

7. **Introduced built-in retry mechanism in `reasoning_mcp_server_os.py`**
   This addresses the issue of frequent failures with the locally deployed Qwen3-235B reasoning model.

8. **Increased tool call timeout from 300s to 1200s**
   This change is especially helpful for the HLE benchmark.
