### PR TITLE
Avoid applying demo-mode truncation in perf tests

### DIFF
--- a/apps/gradio-demo/README.md
+++ b/apps/gradio-demo/README.md
@@ -116,7 +116,7 @@ You can also leverage other frameworks for model serving like Ollama, vLLM, and 
 
 ### 4. **Launch the Application**
    ```bash
-   uv run src/gradio_demo/main.py
+   DEMO_MODE=1 uv run src/gradio_demo/main.py
    ```
 
 ### 5. **Access the Web Interface**

--- a/apps/miroflow-agent/src/core/orchestrator.py
+++ b/apps/miroflow-agent/src/core/orchestrator.py
@@ -14,6 +14,7 @@
 
 import json
 import logging
+import os
 import time
 from datetime import date
 from typing import Any, Dict, List, Optional, Tuple
@@ -476,9 +477,13 @@ class Orchestrator:
                     tool_result = await self.sub_agent_tool_managers[
                         sub_agent_name
                     ].execute_tool_call(server_name, tool_name, arguments)
-                    tool_result = self.post_process_tool_call_result(
-                        tool_name, tool_result
-                    )
+
+                    # Only in demo mode: truncate scrape results to 20,000 chars
+                    # to support more conversation turns. Skipped in perf tests to avoid loss.
+                    if os.environ.get("DEMO_MODE") == "1":
+                        tool_result = self.post_process_tool_call_result(
+                            tool_name, tool_result
+                        )
                     result = (
                         tool_result.get("result")
                         if tool_result.get("result")


### PR DESCRIPTION
This PR fixes a bug where the demo-mode truncation logic was unintentionally applied during performance tests.

* **Background**:
  In demo mode we truncate scrape results to 20,000 characters to support more conversation turns. This is useful for demo stability but not needed in performance testing.

* **Issue**:
  The truncation was being applied in performance tests as well, which led to content loss and caused performance score drops.

* **Fix**:
  Added a `DEMO_MODE` environment variable guard.

  * When `DEMO_MODE=1`: `post_process_tool_call_result` is applied (with truncation).
  * Otherwise: skip truncation to preserve full results in performance tests.