### PR TITLE
Fix bug in used_queries record

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@
   <img src="assets/futurex-09-12.png" width="100%" alt="MiroFlow" />
 </div>
 
----
+______________________________________________________________________
 
 This repo is the official implementation of the MiroMind Research Agent Project. It is a leading-performance, fully open-source system designed to perform multi-step internet research for addressing complex challenges such as future event prediction. The project currently comprises four key components:
 
-- 🤔 **MiroThinker**: an open-source agent foundation model that natively supports tool-assisted reasoning, achieving open-source state-of-the-art performance across multiple benchmarks (e.g., FutureX, GAIA, HLE, xBench-DeepSearch, BrowserComp, and Frames Benchmarks), included in this repo. See [[Quick Start]](#-quick-start) for a quick start.
+- 🤔 **MiroThinker**: an open-source agent foundation model that natively supports tool-assisted reasoning, achieving open-source state-of-the-art performance across multiple benchmarks (e.g., FutureX, GAIA, HLE, xBench-DeepSearch, BrowserComp, and Frames Benchmarks), included in this repo. See [\[Quick Start\]](#-quick-start) for a quick start.
 - 🤖 **MiroFlow**: an open-source research agent framework that offers reproducible state-of-the-art performance across multiple benchmarks. See [MiroFlow](https://github.com/MiroMindAI/MiroFlow).
 - 📊 **MiroVerse**: 147k premium open-source training data supporting research agent training. See [MiroVerse](https://huggingface.co/datasets/miromind-ai/MiroVerse-v0.1).
 - 🚧 **MiroTrain / MiroRL**: The training infra that supports stable and efficient training for the research agent models. See [MiroTrain](https://github.com/MiroMindAI/MiroTrain) / [MiroRL](https://github.com/MiroMindAI/MiroRL)
 
----
+______________________________________________________________________
 
 ## 📋 Table of Contents
 
@@ -53,7 +53,7 @@ This repo is the official implementation of the MiroMind Research Agent Project.
 - 📄 [License](#-license)
 - 🙏 [Acknowledgments](#-acknowledgments-and-contributors)
 
----
+______________________________________________________________________
 
 ## 📰 News & Updates
 
@@ -64,7 +64,7 @@ This repo is the official implementation of the MiroMind Research Agent Project.
 - **\[2025-08-22\]** Introducing streamlined deployment options for MiroThinker models with optimized resource usage and faster startup times. Experience the interactive demo: [🚀 Try Gradio Demo](apps/gradio-demo)
 - **\[2025-08-08\]** [MiroThinker-v0.1](https://huggingface.co/collections/miromind-ai/mirothinker-v01-689301b6d0563321862d44a1) released. Models, framework, and data are now fully open-sourced!
 
----
+______________________________________________________________________
 
 ## 📝 Introduction
 
@@ -120,7 +120,7 @@ We have released the **MiroThinker v0.1** series, including both SFT and DPO var
 
 </details>
 
----
+______________________________________________________________________
 
 ## ✨ Key Features
 
@@ -144,7 +144,7 @@ We have released the **MiroThinker v0.1** series, including both SFT and DPO var
 - **XBench-DeepResearch**: A benchmark for deep research agents. ([website](https://xbench.org/agi/aisearch))
 - **FutureX**: A live benchmark designed for predicting unknown future. ([website](https://futurex-ai.github.io/))
 
----
+______________________________________________________________________
 
 ## 📈 Performance on Benchmarks
 
@@ -240,7 +240,7 @@ We have released the **MiroThinker v0.1** series, including both SFT and DPO var
 
 </details>
 
----
+______________________________________________________________________
 
 ## 🚀 Quick Start
 
@@ -445,7 +445,7 @@ python benchmarks/check_progress/check_progress_gaia-validation-text-103.py /pat
 # Others follow the same pattern
 ```
 
----
+______________________________________________________________________
 
 ## 🔧 Supported Open-Source Tools
 
@@ -455,7 +455,7 @@ One way to access these open-source tools is to purchase them from API providers
 Of course, these tools can also be deployed on local servers.
 For detailed setup and local deployment instructions, please refer to our documentation: [USE-OS-TOOL.md](assets/USE-OS-TOOL.md).
 
----
+______________________________________________________________________
 
 ## 📊 Trace Collection
 
@@ -472,7 +472,7 @@ uv run bash scripts/collect_trace_gpt5.sh
 uv run bash scripts/collect_trace_qwen3.sh
 ```
 
----
+______________________________________________________________________
 
 ## 📞 Support
 

--- a/apps/miroflow-agent/src/core/orchestrator.py
+++ b/apps/miroflow-agent/src/core/orchestrator.py
@@ -506,7 +506,7 @@ class Orchestrator:
                     tool_call_id = await self._stream_tool_call(tool_name, arguments)
                     query_str = self._get_query_str_from_tool_call(tool_name, arguments)
                     if query_str:
-                        cache_name = sub_agent_id + '_' + tool_name
+                        cache_name = sub_agent_id + "_" + tool_name
                         self.used_queries.setdefault(cache_name, defaultdict(int))
                         count = self.used_queries[cache_name][query_str]
                         if count > 0:
@@ -864,7 +864,7 @@ class Orchestrator:
                             tool_name, arguments
                         )
                         if query_str:
-                            cache_name = self.current_agent_id + '_' + tool_name
+                            cache_name = self.current_agent_id + "_" + tool_name
                             self.used_queries.setdefault(cache_name, defaultdict(int))
                             count = self.used_queries[cache_name][query_str]
                             if count > 0:
@@ -897,7 +897,7 @@ class Orchestrator:
                             tool_name, arguments
                         )
                         if query_str:
-                            cache_name = self.current_agent_id + '_' + tool_name
+                            cache_name = self.current_agent_id + "_" + tool_name
                             self.used_queries.setdefault(cache_name, defaultdict(int))
                             count = self.used_queries[cache_name][query_str]
                             if count > 0:

--- a/apps/miroflow-agent/src/core/orchestrator.py
+++ b/apps/miroflow-agent/src/core/orchestrator.py
@@ -91,12 +91,7 @@ class Orchestrator:
             self.llm_client.task_log = task_log
 
         # Record used subtask / q / Query
-        self.used_queries = {
-            "search_and_browse": defaultdict(int),
-            "google_search": defaultdict(int),
-            "sougou_search": defaultdict(int),
-            "scrape_website": defaultdict(int),
-        }
+        self.used_queries = {}
 
     async def _stream_update(self, event_type: str, data: dict):
         """Send streaming update in new SSE protocol format"""
@@ -511,8 +506,9 @@ class Orchestrator:
                     tool_call_id = await self._stream_tool_call(tool_name, arguments)
                     query_str = self._get_query_str_from_tool_call(tool_name, arguments)
                     if query_str:
-                        self.used_queries.setdefault(tool_name, defaultdict(int))
-                        count = self.used_queries[tool_name][query_str]
+                        cache_name = sub_agent_id + '_' + tool_name
+                        self.used_queries.setdefault(cache_name, defaultdict(int))
+                        count = self.used_queries[cache_name][query_str]
                         if count > 0:
                             tool_result = {
                                 "server_name": server_name,
@@ -526,7 +522,7 @@ class Orchestrator:
                                 sub_agent_name
                             ].execute_tool_call(server_name, tool_name, arguments)
                         if "error" not in tool_result:
-                            self.used_queries[tool_name][query_str] += 1
+                            self.used_queries[cache_name][query_str] += 1
                     else:
                         tool_result = await self.sub_agent_tool_managers[
                             sub_agent_name
@@ -868,8 +864,9 @@ class Orchestrator:
                             tool_name, arguments
                         )
                         if query_str:
-                            self.used_queries.setdefault(tool_name, defaultdict(int))
-                            count = self.used_queries[tool_name][query_str]
+                            cache_name = self.current_agent_id + '_' + tool_name
+                            self.used_queries.setdefault(cache_name, defaultdict(int))
+                            count = self.used_queries[cache_name][query_str]
                             if count > 0:
                                 sub_agent_result = f"The query '{query_str}' has already been used in previous {tool_name}. Please try a different query or keyword."
                                 if count >= self.max_repeat_queries:
@@ -878,7 +875,7 @@ class Orchestrator:
                                 sub_agent_result = await self.run_sub_agent(
                                     server_name, arguments["subtask"], keep_tool_result
                                 )
-                            self.used_queries[tool_name][query_str] += 1
+                            self.used_queries[cache_name][query_str] += 1
                         else:
                             sub_agent_result = await self.run_sub_agent(
                                 server_name, arguments["subtask"], keep_tool_result
@@ -900,8 +897,9 @@ class Orchestrator:
                             tool_name, arguments
                         )
                         if query_str:
-                            self.used_queries.setdefault(tool_name, defaultdict(int))
-                            count = self.used_queries[tool_name][query_str]
+                            cache_name = self.current_agent_id + '_' + tool_name
+                            self.used_queries.setdefault(cache_name, defaultdict(int))
+                            count = self.used_queries[cache_name][query_str]
                             if count > 0:
                                 tool_result = {
                                     "server_name": server_name,
@@ -917,7 +915,7 @@ class Orchestrator:
                                     arguments=arguments,
                                 )
                             if "error" not in tool_result:
-                                self.used_queries[tool_name][query_str] += 1
+                                self.used_queries[cache_name][query_str] += 1
                         else:
                             tool_result = (
                                 await self.main_agent_tool_manager.execute_tool_call(


### PR DESCRIPTION
This PR fixes a bug in how `used_queries` were recorded and checked across agents.

Previously, query usage was tracked only at the tool level. As a result, if a query had already been executed in one sub-agent (e.g. Agent A), the same query would be blocked in another sub-agent (e.g. Agent B). This behavior was too restrictive, since different sub-agents should be allowed to perform the same query within their own context.

The update changes the tracking logic to record queries per agent + tool combination instead of globally. Each sub-agent now maintains its own query usage history, ensuring that queries can be reused across agents without conflict. At the same time, repeated queries within the same agent are still correctly detected and handled.

This fix improves correctness and aligns query-tracking behavior with the intended design of independent sub-agent workflows.