### PR TITLE
Refactor model clients to use config-provided API key

### DIFF
--- a/apps/collect-trace/scripts/collect_trace_claude37.sh
+++ b/apps/collect-trace/scripts/collect_trace_claude37.sh
@@ -1,3 +1,11 @@
+# Check if ANTHROPIC_API_KEY is set
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+    echo "Error: ANTHROPIC_API_KEY is not set."
+    exit 1
+else
+    echo "ANTHROPIC_API_KEY detected."
+fi
+
 # Get the directory where the current script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "Current script directory: $SCRIPT_DIR"
@@ -21,6 +29,7 @@ uv run python benchmarks/common_benchmark.py \
     llm=claude-3-7 \
     llm.provider=anthropic \
     llm.model_name=claude-3-7-sonnet-20250219 \
+    llm.api_key="$ANTHROPIC_API_KEY" \
     llm.base_url=https://api.anthropic.com \
     llm.async_client=true \
     benchmark.execution.max_tasks=null \

--- a/apps/collect-trace/scripts/collect_trace_gpt41.sh
+++ b/apps/collect-trace/scripts/collect_trace_gpt41.sh
@@ -1,3 +1,11 @@
+# Check if OPENAI_API_KEY is set
+if [ -z "$OPENAI_API_KEY" ]; then
+    echo "Error: OPENAI_API_KEY is not set."
+    exit 1
+else
+    echo "OPENAI_API_KEY detected."
+fi
+
 # Get the directory where the current script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "Current script directory: $SCRIPT_DIR"
@@ -21,6 +29,7 @@ uv run python benchmarks/common_benchmark.py \
     llm=gpt-5 \
     llm.provider=openai \
     llm.model_name=gpt-4.1-mini \
+    llm.api_key="$OPENAI_API_KEY" \
     llm.base_url=https://api.openai.com/v1 \
     llm.async_client=true \
     benchmark.execution.max_tasks=null \

--- a/apps/collect-trace/scripts/collect_trace_gpt5.sh
+++ b/apps/collect-trace/scripts/collect_trace_gpt5.sh
@@ -1,3 +1,11 @@
+# Check if OPENAI_API_KEY is set
+if [ -z "$OPENAI_API_KEY" ]; then
+    echo "Error: OPENAI_API_KEY is not set."
+    exit 1
+else
+    echo "OPENAI_API_KEY detected."
+fi
+
 # Get the directory where the current script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "Current script directory: $SCRIPT_DIR"
@@ -21,6 +29,7 @@ uv run python benchmarks/common_benchmark.py \
     llm=gpt-5 \
     llm.provider=openai \
     llm.model_name=gpt-5-2025-08-07 \
+    llm.api_key="$OPENAI_API_KEY" \
     llm.base_url=https://api.openai.com/v1 \
     llm.async_client=true \
     benchmark.execution.max_tasks=null \

--- a/apps/collect-trace/scripts/collect_trace_qwen3.sh
+++ b/apps/collect-trace/scripts/collect_trace_qwen3.sh
@@ -21,6 +21,7 @@ uv run python benchmarks/common_benchmark.py \
     llm=qwen-3 \
     llm.provider=qwen \
     llm.model_name=qwen-3-32b \
+    llm.api_key="" \
     llm.base_url=https://your-api.com/v1 \
     llm.async_client=true \
     benchmark.execution.max_tasks=null \

--- a/apps/miroflow-agent/conf/llm/default.yaml
+++ b/apps/miroflow-agent/conf/llm/default.yaml
@@ -7,5 +7,6 @@ top_p: 1.0
 min_p: 0.0
 top_k: -1
 max_tokens: 4096
+api_key: ""
 base_url: https://api.anthropic.com
 keep_tool_result: -1

--- a/apps/miroflow-agent/src/llm/base_client.py
+++ b/apps/miroflow-agent/src/llm/base_client.py
@@ -72,6 +72,7 @@ class BaseClient(ABC):
         self.max_tokens: int = self.cfg.llm.max_tokens
         self.async_client: bool = self.cfg.llm.async_client
         self.keep_tool_result: int = self.cfg.llm.keep_tool_result
+        self.api_key: Optional[str] = self.cfg.llm.get("api_key")
         self.base_url: Optional[str] = self.cfg.llm.get("base_url")
         self.use_tool_calls: Optional[bool] = self.cfg.llm.get("use_tool_calls")
 

--- a/apps/miroflow-agent/src/llm/providers/anthropic_client.py
+++ b/apps/miroflow-agent/src/llm/providers/anthropic_client.py
@@ -15,7 +15,6 @@
 import asyncio
 import dataclasses
 import logging
-import os
 from typing import Any, Dict, List, Tuple, Union
 
 import tiktoken
@@ -47,18 +46,17 @@ class AnthropicClient(BaseClient):
 
     def _create_client(self) -> Union[AsyncAnthropic, Anthropic]:
         """Create LLM client"""
-        api_key = os.environ.get("ANTHROPIC_API_KEY", None)
         http_client_args = {}
 
         if self.async_client:
             return AsyncAnthropic(
-                api_key=api_key,
+                api_key=self.api_key,
                 base_url=self.base_url,
                 http_client=DefaultAsyncHttpxClient(**http_client_args),
             )
         else:
             return Anthropic(
-                api_key=api_key,
+                api_key=self.api_key,
                 base_url=self.base_url,
                 http_client=DefaultHttpxClient(**http_client_args),
             )

--- a/apps/miroflow-agent/src/llm/providers/openai_client.py
+++ b/apps/miroflow-agent/src/llm/providers/openai_client.py
@@ -15,7 +15,6 @@
 import asyncio
 import dataclasses
 import logging
-import os
 from typing import Any, Dict, List, Tuple, Union
 
 import tiktoken
@@ -32,18 +31,16 @@ logger = logging.getLogger("miroflow_agent")
 class OpenAIClient(BaseClient):
     def _create_client(self) -> Union[AsyncOpenAI, OpenAI]:
         """Create LLM client"""
-        api_key = os.environ.get("OPENAI_API_KEY", None)
         http_client_args = {}
-
         if self.async_client:
             return AsyncOpenAI(
-                api_key=api_key,
+                api_key=self.api_key,
                 base_url=self.base_url,
                 http_client=DefaultAsyncHttpxClient(**http_client_args),
             )
         else:
             return OpenAI(
-                api_key=api_key,
+                api_key=self.api_key,
                 base_url=self.base_url,
                 http_client=DefaultHttpxClient(**http_client_args),
             )


### PR DESCRIPTION
This PR refactors how API keys are managed across the model clients. Previously, `openai_client.py` and `anthropic_client.py` directly read from environment variables (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`). This caused conflicts when using OpenAI’s official models as LLM-as-Judge while also switching to non-OpenAI but OpenAI-API-compatible model providers.

Key changes include:

* **Removed environment variable lookups from clients**: Clients now rely solely on the `api_key` passed via configuration.
* **Added `api_key` to default configuration**: A placeholder (`""`) ensures the field exists in all configs.
* **Updated base client initialization**: `api_key` is now read from configuration using `cfg.llm.get("api_key")`.
* **Adjusted benchmarking and tracing scripts**: These scripts now explicitly pass API keys from environment variables into the configuration when needed, maintaining support for LLM-as-Judge workflows.

This ensures a clean separation of concerns:

* Clients only consume the keys explicitly provided by configuration.
* Environment variables are injected at the orchestration/script level, avoiding unintended coupling between different client usages.
