### PR TITLE
Fix resource cleanup issues in stream_events_optimized

### DIFF
--- a/apps/gradio-demo/main.py
+++ b/apps/gradio-demo/main.py
@@ -24,6 +24,10 @@ apply_prompt_patch()
 # Create global cleanup thread pool for operations that won't be affected by asyncio.cancel
 cleanup_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="cleanup")
 
+# Register cleanup on exit to prevent resource leaks
+import atexit
+atexit.register(cleanup_executor.shutdown)
+
 logger = logging.getLogger(__name__)
 
 # Set DEMO_MODE for simplified tool configuration
@@ -399,13 +403,15 @@ async def stream_events_optimized(
             "data": {"workflow_id": workflow_id, "error": f"Stream error: {str(e)}"},
         }
     finally:
-        cancel_event.set()
-        stream_queue.close()
+        cancel_event.set()  # Signal pipeline to stop
         try:
-            future.result(timeout=1.0)
+            # Wait longer for pipeline thread to finish
+            future.result(timeout=5.0)
         except Exception:
-            pass
-        executor.shutdown(wait=False)
+            pass  # Thread may have been cancelled
+        finally:
+            stream_queue.close()  # Close queue after thread is done
+            executor.shutdown(wait=True, cancel_futures=True)
 
 
 # ========================= Gradio Integration =========================


### PR DESCRIPTION
## Summary

Fixes #73 - Resource cleanup issues in `stream_events_optimized` that could cause resource leaks or dropped messages.

### Changes

1. **Global cleanup_executor shutdown**
   - Added `atexit.register(cleanup_executor.shutdown)` to properly shut down the global thread pool on exit
   - Prevents resource leaks from orphaned threads

2. **Race condition fix in finally block**
   - Changed order: now signals cancellation → waits for thread → closes queue → shuts down executor
   - Previously: queue was closed before thread finished, potentially dropping messages

3. **Improved timeout handling**
   - Increased `future.result()` timeout from 1.0s to 5.0s for more graceful shutdown
   - Changed `executor.shutdown(wait=False)` to `shutdown(wait=True, cancel_futures=True)` for proper cleanup

### Testing

- Python syntax verified with `py_compile`
- Changes align with the fix suggestions in issue #73

## Checklist

- [x] Code follows the existing style
- [x] No new dependencies introduced
- [x] Changes are minimal and focused on the bug fix