### PR TITLE
feat: add MiniMax as LLM provider with M2.7 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,8 +714,8 @@ NUM_RUNS=8 \
 AGENT_SET="mirothinker_1.7_keep5_max200" \
 bash scripts/run_evaluate_multiple_runs_gaia-validation-text-103.sh
 
-# Use MiniMax as the LLM provider (supports MiniMax-M2.5 and MiniMax-M2.5-highspeed, 204K context)
-LLM_MODEL="MiniMax-M2.5" \
+# Use MiniMax as the LLM provider (supports MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed, 204K context)
+LLM_MODEL="MiniMax-M2.7" \
 LLM_PROVIDER="minimax" \
 BASE_URL="https://api.minimax.io/v1" \
 API_KEY="your_minimax_api_key" \

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ You can customize the evaluation by setting the following environment variables 
 | `LLM_MODEL` | `"MiroThinker-Agents"` | Agent name identifier |
 | `BASE_URL` | `"https://your-api.com/v1"` | Base URL of your server |
 | `NUM_RUNS` | Varies by benchmark | Number of evaluation runs (3 for most benchmarks, 8 for GAIA/XBench/FutureX/SEAL-0, 32 for AIME2025) |
-| `LLM_PROVIDER` | `"qwen"` | LLM provider (e.g., `qwen`, `openai`, `anthropic`) |
+| `LLM_PROVIDER` | `"qwen"` | LLM provider (e.g., `qwen`, `openai`, `anthropic`, `minimax`) |
 | `AGENT_SET` | `"mirothinker_1.7_keep5_max200"` | Agent configuration (e.g., `mirothinker_1.7_keep5_max200`, `mirothinker_1.7_keep5_max300`.) |
 | `MAX_CONTEXT_LENGTH` | `262144` | Maximum context length (256K) |
 | `MAX_CONCURRENT` | `10` | Maximum concurrent tasks |
@@ -711,6 +711,14 @@ NUM_RUNS=8 LLM_MODEL="MiroThinker-1.7-mini" BASE_URL="https://your-api.com/v1" b
 LLM_MODEL="MiroThinker-1.7-mini" \
 BASE_URL="https://your-api.com/v1" \
 NUM_RUNS=8 \
+AGENT_SET="mirothinker_1.7_keep5_max200" \
+bash scripts/run_evaluate_multiple_runs_gaia-validation-text-103.sh
+
+# Use MiniMax as the LLM provider (supports MiniMax-M2.5 and MiniMax-M2.5-highspeed, 204K context)
+LLM_MODEL="MiniMax-M2.5" \
+LLM_PROVIDER="minimax" \
+BASE_URL="https://api.minimax.io/v1" \
+API_KEY="your_minimax_api_key" \
 AGENT_SET="mirothinker_1.7_keep5_max200" \
 bash scripts/run_evaluate_multiple_runs_gaia-validation-text-103.sh
 

--- a/apps/miroflow-agent/conf/llm/default.yaml
+++ b/apps/miroflow-agent/conf/llm/default.yaml
@@ -1,5 +1,5 @@
 # conf/llm/default.yaml - Default LLM configuration
-provider: "anthropic" # openai, anthropic, qwen
+provider: "anthropic" # openai, anthropic, qwen, minimax
 model_name: "claude-3-7-sonnet-20250219"
 async_client: false
 temperature: 0.3

--- a/apps/miroflow-agent/conf/llm/minimax-m2.5-highspeed.yaml
+++ b/apps/miroflow-agent/conf/llm/minimax-m2.5-highspeed.yaml
@@ -1,0 +1,15 @@
+# conf/llm/minimax-m2.5-highspeed.yaml - MiniMax M2.5 Highspeed configuration
+# Same performance as MiniMax-M2.5, faster and more agile.
+# API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+defaults:
+  - default
+  - _self_
+
+provider: "minimax"
+model_name: "MiniMax-M2.5-highspeed"
+base_url: "https://api.minimax.io/v1"
+max_context_length: 204800
+max_tokens: 16384
+temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
+top_p: 0.95
+repetition_penalty: 1.0

--- a/apps/miroflow-agent/conf/llm/minimax-m2.7-highspeed.yaml
+++ b/apps/miroflow-agent/conf/llm/minimax-m2.7-highspeed.yaml
@@ -1,12 +1,12 @@
-# conf/llm/minimax.yaml - MiniMax LLM configuration
-# MiniMax uses an OpenAI-compatible API.
+# conf/llm/minimax-m2.7-highspeed.yaml - MiniMax M2.7 Highspeed configuration
+# High-speed version of M2.7 for low-latency scenarios.
 # API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
 defaults:
   - default
   - _self_
 
 provider: "minimax"
-model_name: "MiniMax-M2.7"
+model_name: "MiniMax-M2.7-highspeed"
 base_url: "https://api.minimax.io/v1"
 max_context_length: 204800
 max_tokens: 16384

--- a/apps/miroflow-agent/conf/llm/minimax.yaml
+++ b/apps/miroflow-agent/conf/llm/minimax.yaml
@@ -1,0 +1,15 @@
+# conf/llm/minimax.yaml - MiniMax LLM configuration
+# MiniMax uses an OpenAI-compatible API.
+# API docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+defaults:
+  - default
+  - _self_
+
+provider: "minimax"
+model_name: "MiniMax-M2.5"
+base_url: "https://api.minimax.io/v1"
+max_context_length: 204800
+max_tokens: 16384
+temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
+top_p: 0.95
+repetition_penalty: 1.0

--- a/apps/miroflow-agent/src/llm/factory.py
+++ b/apps/miroflow-agent/src/llm/factory.py
@@ -6,7 +6,7 @@ LLM Client Factory module.
 
 This module provides a factory function for creating LLM clients based on
 configuration. It supports multiple providers including OpenAI, Anthropic,
-and Qwen (via OpenAI-compatible API).
+Qwen, and MiniMax (via OpenAI-compatible API).
 """
 
 from typing import Optional, Union
@@ -18,7 +18,7 @@ from .providers.anthropic_client import AnthropicClient
 from .providers.openai_client import OpenAIClient
 
 # Supported LLM providers
-SUPPORTED_PROVIDERS = {"anthropic", "openai", "qwen"}
+SUPPORTED_PROVIDERS = {"anthropic", "openai", "qwen", "minimax"}
 
 
 def ClientFactory(
@@ -55,6 +55,9 @@ def ClientFactory(
         ),
         "qwen": lambda: OpenAIClient(task_id=task_id, task_log=task_log, cfg=config),
         "openai": lambda: OpenAIClient(task_id=task_id, task_log=task_log, cfg=config),
+        "minimax": lambda: OpenAIClient(
+            task_id=task_id, task_log=task_log, cfg=config
+        ),
     }
 
     factory = client_creators.get(provider)


### PR DESCRIPTION
## Summary
- Add MiniMax as a new LLM provider via OpenAI-compatible API
- Support MiniMax-M2.7 (default), MiniMax-M2.7-highspeed, MiniMax-M2.5, and MiniMax-M2.5-highspeed models
- Add Hydra config files for easy model switching
- Update README with MiniMax usage examples

## Changes
- Add `minimax` provider to factory.py using OpenAIClient
- Add config files: minimax.yaml (M2.7 default), minimax-m2.7-highspeed.yaml, minimax-m2.5-highspeed.yaml
- Update README with MiniMax provider documentation

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities. The OpenAI-compatible API makes integration seamless.

## Testing
- Config files validated (YAML parsing)
- Factory pattern tested with minimax provider