### PR TITLE
feat: add Tavily MCP server to miroflow-tools library

### DIFF
--- a/libs/miroflow-tools/pyproject.toml
+++ b/libs/miroflow-tools/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "markitdown-mcp>=0.0.1a3",
     "google-genai",
     "aiohttp",
-    "redis"
+    "redis",
+    "tavily-python>=0.5.0"
 ]
 
 [build-system]

--- a/libs/miroflow-tools/src/miroflow_tools/mcp_servers/tavily_mcp_server.py
+++ b/libs/miroflow-tools/src/miroflow_tools/mcp_servers/tavily_mcp_server.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025 MiroMind
+# This source code is licensed under the Apache 2.0 License.
+
+"""
+Tavily-backed MCP server providing a tavily_search tool as a parallel
+alternative to the Serper-backed google_search tool.
+"""
+
+import json
+import os
+
+from mcp.server.fastmcp import FastMCP
+from tavily import TavilyClient
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY", "")
+
+# Initialize FastMCP server
+mcp = FastMCP("tavily-mcp-server")
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=4, max=10),
+    retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+)
+def _tavily_search_request(client: TavilyClient, **kwargs) -> dict:
+    """Execute a Tavily search with retry logic."""
+    return client.search(**kwargs)
+
+
+@mcp.tool()
+def tavily_search(
+    query: str,
+    max_results: int = 10,
+    search_depth: str = "basic",
+    topic: str = "general",
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
+    time_range: str | None = None,
+):
+    """
+    Tool to perform web searches via Tavily API and retrieve rich results.
+
+    It returns organic search results with titles, URLs, content snippets,
+    and relevance scores.
+
+    Args:
+        query: Search query string (max 400 characters recommended)
+        max_results: Number of results to return (default: 10)
+        search_depth: Search depth - 'basic' (fast, 1 credit) or 'advanced' (thorough, 2 credits)
+        topic: Search topic category - 'general', 'news', or 'finance'
+        include_domains: Optional list of domains to restrict results to
+        exclude_domains: Optional list of domains to exclude from results
+        time_range: Optional time range filter ('day', 'week', 'month', 'year')
+
+    Returns:
+        JSON string containing search results and metadata.
+    """
+    # Check for API key
+    if not TAVILY_API_KEY:
+        return json.dumps(
+            {
+                "success": False,
+                "error": "TAVILY_API_KEY environment variable not set",
+                "results": [],
+            },
+            ensure_ascii=False,
+        )
+
+    # Validate required parameter
+    if not query or not query.strip():
+        return json.dumps(
+            {
+                "success": False,
+                "error": "Search query 'query' is required and cannot be empty",
+                "results": [],
+            },
+            ensure_ascii=False,
+        )
+
+    try:
+        client = TavilyClient(api_key=TAVILY_API_KEY)
+
+        # Build keyword arguments
+        kwargs = {
+            "query": query.strip(),
+            "max_results": max_results,
+            "search_depth": search_depth,
+            "topic": topic,
+        }
+
+        if include_domains:
+            kwargs["include_domains"] = include_domains
+        if exclude_domains:
+            kwargs["exclude_domains"] = exclude_domains
+        if time_range:
+            kwargs["time_range"] = time_range
+
+        # Make the API request with retry
+        data = _tavily_search_request(client, **kwargs)
+
+        return json.dumps(data, ensure_ascii=False)
+
+    except Exception as e:
+        return json.dumps(
+            {"success": False, "error": f"Unexpected error: {str(e)}", "results": []},
+            ensure_ascii=False,
+        )
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/libs/miroflow-tools/src/miroflow_tools/mcp_servers/tavily_mcp_server.py
+++ b/libs/miroflow-tools/src/miroflow_tools/mcp_servers/tavily_mcp_server.py
@@ -9,6 +9,7 @@ alternative to the Serper-backed google_search tool.
 import json
 import os
 
+import httpx
 from mcp.server.fastmcp import FastMCP
 from tavily import TavilyClient
 from tenacity import (
@@ -18,6 +19,7 @@ from tenacity import (
     wait_exponential,
 )
 
+# Obtain from https://app.tavily.com
 TAVILY_API_KEY = os.getenv("TAVILY_API_KEY", "")
 
 # Initialize FastMCP server
@@ -27,7 +29,7 @@ mcp = FastMCP("tavily-mcp-server")
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=10),
-    retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+    retry=retry_if_exception_type((httpx.ConnectError, httpx.TimeoutException)),
 )
 def _tavily_search_request(client: TavilyClient, **kwargs) -> dict:
     """Execute a Tavily search with retry logic."""


### PR DESCRIPTION
## Summary

- Added a new `tavily_mcp_server.py` FastMCP server in the miroflow-tools library, providing a `tavily_search` tool as a parallel alternative to the existing Serper-based `google_search` tool.
- The new server follows the same retry/error-handling patterns as `serper_mcp_server.py` (tenacity retries, JSON error responses, `if __name__ == '__main__': mcp.run()` entry point).
- Added `tavily-python>=0.5.0` dependency to `pyproject.toml`.

## Files Changed

- `libs/miroflow-tools/src/miroflow_tools/mcp_servers/tavily_mcp_server.py` (new file)
- `libs/miroflow-tools/pyproject.toml` (added dependency)

## Dependency Changes

- Added `tavily-python>=0.5.0` to `libs/miroflow-tools/pyproject.toml`

## Environment Variable Changes

- New: `TAVILY_API_KEY` — read by `tavily_mcp_server.py` to authenticate with the Tavily API

## Notes for Reviewers

- Existing Serper search server and its dependencies/env vars are unchanged.
- The Tavily tool exposes parameters for `search_depth`, `topic`, `include_domains`, `exclude_domains`, and `time_range` to leverage Tavily's filtering capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 2 attempt(s)
- Final review: The Tavily MCP server implementation is a clean additive migration. The core logic is sound, the dependency is properly added to pyproject.toml, and the code style is consistent with the existing serper_mcp_server.py. Attempt 2 correctly fixed the retry exception types to use httpx exceptions (httpx.ConnectError / httpx.TimeoutException) rather than Python built-ins. No regressions were introduced. Three minor issues remain: httpx and tenacity are used as direct imports but not declared as explicit dependencies in pyproject.toml (both are transitively available—httpx via tavily-python, and tenacity is a pre-existing undeclared dep already used in serper_mcp_server.py); the TavilyClient is instantiated on every call rather than being module-level; and there is no .env.example or README update documenting the new TAVILY_API_KEY variable (though an inline comment was added).
