### PR TITLE
docs: add WSL uv sync memory allocation troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,6 +890,21 @@ bash scripts/collect_trace_qwen3.sh
 1. **Review logs**: Check `logs/` directory for detailed error messages
 1. **Verify data path**: Ensure benchmark data is downloaded and in correct location
 
+#### **Q: `uv sync` fails with memory allocation error on WSL**
+
+**A:** WSL2 imposes a memory cap that can cause `uv sync` to fail when building heavy packages (e.g. `transformers`, `pillow`). Two options:
+
+1. **Increase WSL2 memory limit** (recommended): Create or edit `%UserProfile%\.wslconfig` on your Windows host, then restart WSL (`wsl --shutdown`):
+   ```ini
+   [wsl2]
+   memory=8GB
+   ```
+
+2. **Limit parallel package builds** (no restart required): Set the `UV_CONCURRENT_BUILDS` environment variable before running `uv sync`:
+   ```bash
+   UV_CONCURRENT_BUILDS=1 uv sync
+   ```
+
 #### **Q: Out of memory errors**
 
 **A:** Solutions:


### PR DESCRIPTION
Fixes #101

## Problem
On WSL2, running `uv sync` in `apps/miroflow-agent` can fail with a memory allocation error. WSL2 imposes a default memory cap (often 2–4 GB depending on host RAM) that is insufficient when building heavy packages like `transformers` or `pillow` in parallel.

## Solution
Add a dedicated FAQ entry in the troubleshooting guide covering two workarounds:
1. Increasing the WSL2 memory limit via `%UserProfile%\.wslconfig` (recommended, persistent)
2. Limiting parallel package builds with `UV_CONCURRENT_BUILDS=1 uv sync` (no restart required)

## Testing
Verified that the new FAQ entry renders correctly in Markdown and the commands are accurate per the UV and WSL2 documentation.