### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/apps/gradio-demo/.env.example
+++ b/apps/gradio-demo/.env.example
@@ -2,6 +2,9 @@
 SERPER_API_KEY=your_serper_key
 SERPER_BASE_URL="https://google.serper.dev"
 
+# API for Exa AI-powered Search (optional)
+EXA_API_KEY=your_exa_api_key
+
 # API for Web Scraping (recommend)
 JINA_API_KEY=your_jina_key
 JINA_BASE_URL="https://r.jina.ai"

--- a/apps/miroflow-agent/.env.example
+++ b/apps/miroflow-agent/.env.example
@@ -2,6 +2,9 @@
 SERPER_API_KEY=your_serper_key
 SERPER_BASE_URL="https://google.serper.dev"
 
+# API for Exa AI-powered Search (optional)
+EXA_API_KEY=your_exa_api_key
+
 # API for Web Scraping (recommend)
 JINA_API_KEY=your_jina_key
 JINA_BASE_URL="https://r.jina.ai"

--- a/apps/miroflow-agent/src/config/settings.py
+++ b/apps/miroflow-agent/src/config/settings.py
@@ -55,6 +55,9 @@ ANTHROPIC_BASE_URL = os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 OPENAI_BASE_URL = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
 
+# API for Exa Search
+EXA_API_KEY = os.environ.get("EXA_API_KEY")
+
 # API for Sogou Search
 TENCENTCLOUD_SECRET_ID = os.environ.get("TENCENTCLOUD_SECRET_ID")
 TENCENTCLOUD_SECRET_KEY = os.environ.get("TENCENTCLOUD_SECRET_KEY")
@@ -108,6 +111,31 @@ def create_mcp_server_parameters(cfg: DictConfig, agent_cfg: DictConfig):
                         "SERPER_BASE_URL": SERPER_BASE_URL,
                         "JINA_API_KEY": JINA_API_KEY,
                         "JINA_BASE_URL": JINA_BASE_URL,
+                    },
+                ),
+            }
+        )
+
+    if (
+        agent_cfg.get("tools", None) is not None
+        and "tool-exa-search" in agent_cfg["tools"]
+    ):
+        if not EXA_API_KEY:
+            raise ValueError(
+                "EXA_API_KEY not set, tool-exa-search will be unavailable."
+            )
+
+        configs.append(
+            {
+                "name": "tool-exa-search",
+                "params": StdioServerParameters(
+                    command=sys.executable,
+                    args=[
+                        "-m",
+                        "miroflow_tools.mcp_servers.exa_search_mcp_server",
+                    ],
+                    env={
+                        "EXA_API_KEY": EXA_API_KEY,
                     },
                 ),
             }
@@ -461,6 +489,7 @@ def get_env_info(cfg: DictConfig) -> dict:
         ),
         # API Keys (masked for security)
         "has_serper_api_key": bool(SERPER_API_KEY),
+        "has_exa_api_key": bool(EXA_API_KEY),
         "has_jina_api_key": bool(JINA_API_KEY),
         "has_anthropic_api_key": bool(ANTHROPIC_API_KEY),
         "has_openai_api_key": bool(OPENAI_API_KEY),

--- a/libs/miroflow-tools/pyproject.toml
+++ b/libs/miroflow-tools/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "playwright>=1.40.0",
     "requests>=2.32.0",
     "e2b-code-interpreter==1.2.1",
+    "exa-py>=2.0.0",
     "wikipedia",
     "mutagen",
     "markitdown-mcp>=0.0.1a3",

--- a/libs/miroflow-tools/src/miroflow_tools/mcp_servers/exa_search_mcp_server.py
+++ b/libs/miroflow-tools/src/miroflow_tools/mcp_servers/exa_search_mcp_server.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2025 MiroMind
+# This source code is licensed under the Apache 2.0 License.
+
+"""
+Exa AI-powered search MCP server.
+
+Provides web search with built-in content retrieval (highlights, text, summary)
+through the Exa API. Supports multiple search types, domain/text filtering,
+category filtering, and date range queries.
+"""
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+EXA_API_KEY = os.getenv("EXA_API_KEY", "")
+
+# Initialize FastMCP server
+mcp = FastMCP("exa-search-mcp-server")
+
+
+def _get_exa_client():
+    """Create and return an Exa client with integration tracking header."""
+    from exa_py import Exa
+
+    client = Exa(api_key=EXA_API_KEY)
+    client.headers["x-exa-integration"] = "mirothinker"
+    return client
+
+
+@mcp.tool()
+def exa_search(
+    q: str,
+    search_type: str = "auto",
+    num_results: int = 10,
+    content_mode: str = "highlights",
+    category: str | None = None,
+    include_domains: str | None = None,
+    exclude_domains: str | None = None,
+    include_text: str | None = None,
+    exclude_text: str | None = None,
+    start_published_date: str | None = None,
+    end_published_date: str | None = None,
+) -> str:
+    """
+    Perform AI-powered web search via Exa API with built-in content retrieval.
+
+    Unlike traditional keyword search, Exa uses neural search to understand
+    query meaning and return semantically relevant results with content.
+
+    Args:
+        q: Search query string. For best results, phrase as a natural language
+            statement describing the ideal page (e.g., "research paper about
+            transformer architectures for code generation" rather than
+            "transformer code generation paper").
+        search_type: Search type. Options: 'auto' (default, intelligently
+            combines methods), 'neural' (embedding-based), 'fast' (optimized
+            for speed).
+        num_results: Number of results to return (default: 10, max: 100).
+        content_mode: Content retrieval mode. Options: 'highlights' (default,
+            key passages), 'text' (full page text), 'summary' (LLM-generated
+            summary), 'none' (URLs and titles only).
+        category: Filter by content category. Options: 'research paper', 'news',
+            'company', 'personal site', 'financial report', 'people'.
+        include_domains: Comma-separated list of domains to restrict results to
+            (e.g., "arxiv.org,github.com").
+        exclude_domains: Comma-separated list of domains to exclude from results
+            (e.g., "pinterest.com,quora.com").
+        include_text: Text that must appear in the results (single phrase, up to
+            5 words).
+        exclude_text: Text that must not appear in the results.
+        start_published_date: Filter results published after this date
+            (ISO 8601 format, e.g., "2024-01-01T00:00:00.000Z").
+        end_published_date: Filter results published before this date
+            (ISO 8601 format, e.g., "2024-12-31T23:59:59.000Z").
+
+    Returns:
+        JSON string containing search results with content.
+    """
+    if not EXA_API_KEY:
+        return json.dumps(
+            {
+                "success": False,
+                "error": "EXA_API_KEY environment variable not set",
+                "results": [],
+            },
+            ensure_ascii=False,
+        )
+
+    if not q or not q.strip():
+        return json.dumps(
+            {
+                "success": False,
+                "error": "Search query 'q' is required and cannot be empty",
+                "results": [],
+            },
+            ensure_ascii=False,
+        )
+
+    try:
+        client = _get_exa_client()
+
+        # Build search kwargs
+        kwargs: Dict[str, Any] = {
+            "query": q.strip(),
+            "type": search_type,
+            "num_results": min(num_results, 100),
+        }
+
+        # Content retrieval options
+        if content_mode == "highlights":
+            kwargs["highlights"] = {"max_characters": 4000}
+        elif content_mode == "text":
+            kwargs["text"] = {"max_characters": 10000}
+        elif content_mode == "summary":
+            kwargs["summary"] = True
+
+        # Category filtering
+        if category:
+            kwargs["category"] = category
+
+        # Domain filtering
+        if include_domains:
+            kwargs["include_domains"] = [
+                d.strip() for d in include_domains.split(",") if d.strip()
+            ]
+        if exclude_domains:
+            kwargs["exclude_domains"] = [
+                d.strip() for d in exclude_domains.split(",") if d.strip()
+            ]
+
+        # Text filtering
+        if include_text:
+            kwargs["include_text"] = [include_text.strip()]
+        if exclude_text:
+            kwargs["exclude_text"] = [exclude_text.strip()]
+
+        # Date range filtering
+        if start_published_date:
+            kwargs["start_published_date"] = start_published_date
+        if end_published_date:
+            kwargs["end_published_date"] = end_published_date
+
+        # Execute search with content retrieval
+        use_contents = content_mode and content_mode != "none"
+        if use_contents:
+            response = client.search_and_contents(**kwargs)
+        else:
+            # Remove content-related keys for plain search
+            kwargs.pop("highlights", None)
+            kwargs.pop("text", None)
+            kwargs.pop("summary", None)
+            response = client.search(**kwargs)
+
+        # Process results
+        results: List[Dict[str, Any]] = []
+        for result in response.results:
+            entry: Dict[str, Any] = {
+                "title": getattr(result, "title", "") or "",
+                "url": getattr(result, "url", "") or "",
+            }
+
+            # Add content based on mode
+            if content_mode == "highlights":
+                highlights = getattr(result, "highlights", None)
+                if highlights:
+                    entry["highlights"] = highlights
+            elif content_mode == "text":
+                text = getattr(result, "text", None)
+                if text:
+                    entry["text"] = text
+            elif content_mode == "summary":
+                summary = getattr(result, "summary", None)
+                if summary:
+                    entry["summary"] = summary
+
+            # Add optional metadata
+            published_date = getattr(result, "published_date", None)
+            if published_date:
+                entry["publishedDate"] = published_date
+
+            author = getattr(result, "author", None)
+            if author:
+                entry["author"] = author
+
+            results.append(entry)
+
+        return json.dumps(
+            {"success": True, "results": results},
+            ensure_ascii=False,
+        )
+
+    except Exception as e:
+        return json.dumps(
+            {"success": False, "error": f"Exa search error: {str(e)}", "results": []},
+            ensure_ascii=False,
+        )
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary

- Add **Exa** as an alternative search provider MCP server alongside Serper/Sogou, providing AI-powered neural search with built-in content retrieval
- New `exa_search` tool supports multiple search types (`auto`, `neural`, `fast`), content modes (`highlights`, `text`, `summary`), category filtering, domain filtering, text filtering, and date range queries
- Register `tool-exa-search` in the agent configuration system so it can be enabled via YAML configs

## Usage

1. Set `EXA_API_KEY` in your `.env` file
2. Add `tool-exa-search` to your agent YAML config:

```yaml
main_agent:
  tools:
    - tool-exa-search
    - tool-python
```

3. The agent can now call `exa_search` with natural language queries:

```python
# Example tool call from the agent
exa_search(
    q="recent research on transformer architectures for code generation",
    content_mode="highlights",
    category="research paper",
    num_results=10
)
```

## Files Changed

- `libs/miroflow-tools/src/miroflow_tools/mcp_servers/exa_search_mcp_server.py` -- new Exa search MCP server
- `apps/miroflow-agent/src/config/settings.py` -- register `tool-exa-search` and `EXA_API_KEY`
- `libs/miroflow-tools/pyproject.toml` -- add `exa-py>=2.0.0` dependency
- `apps/miroflow-agent/.env.example` -- add `EXA_API_KEY` entry
- `apps/gradio-demo/.env.example` -- add `EXA_API_KEY` entry

## Test Plan

- [ ] Set `EXA_API_KEY` and run `python -m miroflow_tools.mcp_servers.exa_search_mcp_server` to verify server starts
- [ ] Add `tool-exa-search` to an agent config and verify it connects as an MCP tool
- [ ] Test `exa_search` with various query types, content modes, and filters
- [ ] Verify graceful error handling when `EXA_API_KEY` is not set
- [ ] Confirm existing search tools (Serper, Sogou) are unaffected