### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/apps/miroflow-agent/pyproject.toml
+++ b/apps/miroflow-agent/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "markitdown-mcp>=0.0.1a3",
     "markitdown>=0.1.1",
     "regex>=2024.11.6",
+    "litellm>=1.60.0,<2.0.0",
     "openai>=1.78.1",
     "tenacity>=9.1.2",
     "transformers>=4.51.3",

--- a/apps/miroflow-agent/src/llm/factory.py
+++ b/apps/miroflow-agent/src/llm/factory.py
@@ -15,10 +15,11 @@ from omegaconf import DictConfig, OmegaConf
 
 from ..logging.task_logger import TaskLog
 from .providers.anthropic_client import AnthropicClient
+from .providers.litellm_client import LiteLLMClient
 from .providers.openai_client import OpenAIClient
 
 # Supported LLM providers
-SUPPORTED_PROVIDERS = {"anthropic", "openai", "qwen"}
+SUPPORTED_PROVIDERS = {"anthropic", "litellm", "openai", "qwen"}
 
 
 def ClientFactory(
@@ -51,6 +52,9 @@ def ClientFactory(
 
     client_creators = {
         "anthropic": lambda: AnthropicClient(
+            task_id=task_id, task_log=task_log, cfg=config
+        ),
+        "litellm": lambda: LiteLLMClient(
             task_id=task_id, task_log=task_log, cfg=config
         ),
         "qwen": lambda: OpenAIClient(task_id=task_id, task_log=task_log, cfg=config),

--- a/apps/miroflow-agent/src/llm/providers/__init__.py
+++ b/apps/miroflow-agent/src/llm/providers/__init__.py
@@ -2,9 +2,11 @@
 # This source code is licensed under the MIT License.
 
 from .anthropic_client import AnthropicClient
+from .litellm_client import LiteLLMClient
 from .openai_client import OpenAIClient
 
 __all__ = [
     "AnthropicClient",
+    "LiteLLMClient",
     "OpenAIClient",
 ]

--- a/apps/miroflow-agent/src/llm/providers/litellm_client.py
+++ b/apps/miroflow-agent/src/llm/providers/litellm_client.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2025 MiroMind
+# This source code is licensed under the MIT License.
+
+"""
+LiteLLM-compatible LLM client implementation.
+
+This module provides the LiteLLMClient class for interacting with 100+
+LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Cohere,
+Ollama, etc.) through a single unified interface via LiteLLM.
+
+It extends OpenAIClient and overrides _create_client() to route API calls
+through litellm.completion/acompletion instead of the OpenAI SDK directly.
+Since LiteLLM returns OpenAI-compatible responses, all retry logic, token
+tracking, and response processing from OpenAIClient work unchanged.
+"""
+
+import dataclasses
+import logging
+from typing import Union
+
+from .openai_client import OpenAIClient
+
+logger = logging.getLogger("miroflow_agent")
+
+
+class _SyncCompletions:
+    """Sync proxy that delegates to litellm.completion."""
+
+    @staticmethod
+    def create(**kwargs):
+        import litellm
+
+        kwargs["drop_params"] = True
+        return litellm.completion(**kwargs)
+
+
+class _AsyncCompletions:
+    """Async proxy that delegates to litellm.acompletion."""
+
+    @staticmethod
+    async def create(**kwargs):
+        import litellm
+
+        kwargs["drop_params"] = True
+        return await litellm.acompletion(**kwargs)
+
+
+class _Chat:
+    def __init__(self, completions):
+        self.completions = completions
+
+
+class _LiteLLMProxy:
+    """Lightweight proxy mimicking the OpenAI client interface.
+
+    Routes calls to litellm.completion (sync) or litellm.acompletion (async)
+    so that OpenAIClient's retry logic and response processing work unchanged.
+    """
+
+    def __init__(self, async_mode: bool = False):
+        completions = _AsyncCompletions() if async_mode else _SyncCompletions()
+        self.chat = _Chat(completions)
+
+
+@dataclasses.dataclass
+class LiteLLMClient(OpenAIClient):
+    """LLM client that routes to 100+ providers via LiteLLM.
+
+    Extends OpenAIClient and replaces the OpenAI SDK client with a
+    lightweight proxy that delegates to litellm.completion/acompletion.
+    All retry logic, token tracking, and response processing are inherited.
+
+    Configure via Hydra config:
+        llm:
+          provider: litellm
+          model_name: anthropic/claude-3-haiku  # any LiteLLM model string
+          api_key: ...  # optional, litellm reads provider env vars automatically
+    """
+
+    def _create_client(self) -> _LiteLLMProxy:
+        """Create a LiteLLM proxy client instead of a direct OpenAI client."""
+        return _LiteLLMProxy(async_mode=self.async_client)

--- a/tests/test_litellm_client.py
+++ b/tests/test_litellm_client.py
@@ -1,0 +1,383 @@
+"""Tests for the LiteLLM client."""
+
+import types as builtin_types
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake response helpers (OpenAI-compatible format)
+# ---------------------------------------------------------------------------
+
+
+class _Usage:
+    def __init__(self, prompt=10, completion=5):
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.prompt_tokens_details = None
+
+
+class _Msg:
+    def __init__(self, content="hello", role="assistant", tool_calls=None):
+        self.content = content
+        self.role = role
+        self.tool_calls = tool_calls
+
+
+class _Choice:
+    def __init__(self, content="hello", finish_reason="stop"):
+        self.message = _Msg(content=content)
+        self.finish_reason = finish_reason
+
+
+class _Response:
+    def __init__(self, content="hello", finish_reason="stop", usage=None):
+        self.choices = [_Choice(content=content, finish_reason=finish_reason)]
+        self.usage = usage or _Usage()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_litellm(response_content="hello"):
+    import sys
+
+    fake = builtin_types.ModuleType("litellm")
+    fake.completion = mock.MagicMock(return_value=_Response(response_content))
+
+    async def _async_completion(**kwargs):
+        return _Response(response_content)
+
+    fake.acompletion = _async_completion
+    sys.modules["litellm"] = fake
+    return fake
+
+
+def _uninstall_fake_litellm():
+    import sys
+
+    sys.modules.pop("litellm", None)
+
+
+# ---------------------------------------------------------------------------
+# Sync proxy: basic call dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSyncProxy:
+    def setup_method(self):
+        self.fake = _install_fake_litellm("sync response")
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_returns_response_content(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        result = proxy.chat.completions.create(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert result.choices[0].message.content == "sync response"
+
+    def test_calls_litellm_completion(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        self.fake.completion.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Sync proxy: parameter forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestSyncProxyParams:
+    def setup_method(self):
+        self.fake = _install_fake_litellm()
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_drop_params_always_true(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(model="x", messages=[])
+        assert self.fake.completion.call_args[1]["drop_params"] is True
+
+    def test_model_forwarded(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(model="anthropic/claude-3-haiku", messages=[])
+        assert self.fake.completion.call_args[1]["model"] == "anthropic/claude-3-haiku"
+
+    def test_messages_forwarded(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        msgs = [{"role": "user", "content": "test"}]
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(model="x", messages=msgs)
+        assert self.fake.completion.call_args[1]["messages"] == msgs
+
+    def test_temperature_forwarded(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(model="x", messages=[], temperature=0.7)
+        assert self.fake.completion.call_args[1]["temperature"] == 0.7
+
+    def test_max_tokens_forwarded(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(model="x", messages=[], max_tokens=2048)
+        assert self.fake.completion.call_args[1]["max_tokens"] == 2048
+
+    def test_top_p_forwarded(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(model="x", messages=[], top_p=0.95)
+        assert self.fake.completion.call_args[1]["top_p"] == 0.95
+
+    def test_stream_forwarded(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(model="x", messages=[], stream=False)
+        assert self.fake.completion.call_args[1]["stream"] is False
+
+    def test_extra_body_forwarded(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(
+            model="x", messages=[], extra_body={"thinking": {"type": "enabled"}}
+        )
+        assert self.fake.completion.call_args[1]["extra_body"] == {
+            "thinking": {"type": "enabled"}
+        }
+
+    def test_user_cannot_override_drop_params(self):
+        """drop_params=True is always enforced even if user passes False."""
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(model="x", messages=[], drop_params=False)
+        # Our proxy sets drop_params=True AFTER kwargs, so it always wins
+        assert self.fake.completion.call_args[1]["drop_params"] is True
+
+
+# ---------------------------------------------------------------------------
+# Async proxy
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncProxy:
+    def setup_method(self):
+        self.fake = _install_fake_litellm("async response")
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    @pytest.mark.asyncio
+    async def test_returns_response_content(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=True)
+        result = await proxy.chat.completions.create(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert result.choices[0].message.content == "async response"
+
+    @pytest.mark.asyncio
+    async def test_drop_params_true(self):
+        """Verify drop_params is passed in async mode too."""
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=True)
+        # acompletion is a real async function, not a mock, so just verify it runs
+        result = await proxy.chat.completions.create(model="x", messages=[])
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Factory and registration
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryRegistration:
+    def setup_method(self):
+        _install_fake_litellm()
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_litellm_in_supported_providers(self):
+        from src.llm.factory import SUPPORTED_PROVIDERS
+
+        assert "litellm" in SUPPORTED_PROVIDERS
+
+    def test_litellm_in_providers_init_all(self):
+        from src.llm.providers import __all__
+
+        assert "LiteLLMClient" in __all__
+
+    def test_litellm_importable_from_providers(self):
+        from src.llm.providers import LiteLLMClient
+
+        assert LiteLLMClient is not None
+
+    def test_litellm_client_extends_openai_client(self):
+        from src.llm.providers.litellm_client import LiteLLMClient
+        from src.llm.providers.openai_client import OpenAIClient
+
+        assert issubclass(LiteLLMClient, OpenAIClient)
+
+    def test_unsupported_provider_raises(self):
+        from omegaconf import OmegaConf
+        from src.llm.factory import ClientFactory
+
+        cfg = OmegaConf.create({"llm": {"provider": "nonexistent"}})
+        with pytest.raises(ValueError, match="Unsupported provider"):
+            ClientFactory(task_id="t", cfg=cfg)
+
+
+# ---------------------------------------------------------------------------
+# _create_client behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCreateClient:
+    def setup_method(self):
+        self.fake = _install_fake_litellm()
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_returns_proxy_instance(self):
+        from src.llm.providers.litellm_client import LiteLLMClient, _LiteLLMProxy
+
+        client = object.__new__(LiteLLMClient)
+        client.async_client = False
+        client.task_id = "test"
+        result = client._create_client()
+        assert isinstance(result, _LiteLLMProxy)
+
+    def test_sync_mode_uses_sync_completions(self):
+        from src.llm.providers.litellm_client import LiteLLMClient, _SyncCompletions
+
+        client = object.__new__(LiteLLMClient)
+        client.async_client = False
+        client.task_id = "test"
+        proxy = client._create_client()
+        assert isinstance(proxy.chat.completions, _SyncCompletions)
+
+    def test_async_mode_uses_async_completions(self):
+        from src.llm.providers.litellm_client import LiteLLMClient, _AsyncCompletions
+
+        client = object.__new__(LiteLLMClient)
+        client.async_client = True
+        client.task_id = "test"
+        proxy = client._create_client()
+        assert isinstance(proxy.chat.completions, _AsyncCompletions)
+
+    def test_proxy_has_chat_attribute(self):
+        from src.llm.providers.litellm_client import LiteLLMClient
+
+        client = object.__new__(LiteLLMClient)
+        client.async_client = False
+        client.task_id = "test"
+        proxy = client._create_client()
+        assert hasattr(proxy, "chat")
+        assert hasattr(proxy.chat, "completions")
+        assert hasattr(proxy.chat.completions, "create")
+
+
+# ---------------------------------------------------------------------------
+# Response format compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestResponseFormat:
+    def setup_method(self):
+        self.fake = _install_fake_litellm()
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_response_has_choices(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        result = proxy.chat.completions.create(model="x", messages=[])
+        assert hasattr(result, "choices")
+        assert len(result.choices) > 0
+
+    def test_response_has_usage(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        result = proxy.chat.completions.create(model="x", messages=[])
+        assert hasattr(result, "usage")
+        assert hasattr(result.usage, "prompt_tokens")
+        assert hasattr(result.usage, "completion_tokens")
+
+    def test_response_has_finish_reason(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        result = proxy.chat.completions.create(model="x", messages=[])
+        assert result.choices[0].finish_reason == "stop"
+
+    def test_response_message_has_content_and_role(self):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        result = proxy.chat.completions.create(model="x", messages=[])
+        msg = result.choices[0].message
+        assert hasattr(msg, "content")
+        assert hasattr(msg, "role")
+
+
+# ---------------------------------------------------------------------------
+# Multi-provider model strings
+# ---------------------------------------------------------------------------
+
+
+class TestMultiProviderModels:
+    def setup_method(self):
+        self.fake = _install_fake_litellm()
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "openai/gpt-4o",
+            "anthropic/claude-3-haiku",
+            "bedrock/anthropic.claude-v2",
+            "vertex_ai/gemini-pro",
+            "groq/llama3-70b-8192",
+            "ollama/llama3",
+            "azure/gpt-4o",
+        ],
+    )
+    def test_model_string_forwarded_to_litellm(self, model):
+        from src.llm.providers.litellm_client import _LiteLLMProxy
+
+        proxy = _LiteLLMProxy(async_mode=False)
+        proxy.chat.completions.create(model=model, messages=[])
+        assert self.fake.completion.call_args[1]["model"] == model


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Adds `LiteLLMClient` as a new LLM provider extending `OpenAIClient`                                                                                                                                              
  - Gives users access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Cohere, Ollama, etc.) through a single unified interface
  - Users switch providers by changing `llm.model_name` in the Hydra config, no code changes needed                                                                                                                  
  - Follows the existing provider pattern by extending `OpenAIClient` with a lightweight proxy that routes to `litellm.completion`/`litellm.acompletion`                                                             
                                                                                                                                                                                                                     
  ---                                                                                                                                                                                                                
                                                                                                                                                                                                                     
  - **What kind of change does this PR introduce?** Feature, adds LiteLLM as a new LLM provider                                                                                                                      
   
  - **Why was this change needed?** MiroThinker currently supports OpenAI, Anthropic, and Qwen providers. LiteLLM provides a unified interface to 100+ providers through a single `completion()` call. Users switch  
  providers by changing the model string in config.
                                                                                                                                                                                                                     
  - **Other information**: See sections below.
                                                                                                                                                                          
   
  ---                                                                                                                                                                                                                
                  
  ## What Changed

  | File | Change |
  |---|---|
  | `apps/miroflow-agent/src/llm/providers/litellm_client.py` | New `LiteLLMClient` extending `OpenAIClient` with `_LiteLLMProxy` |
  | `apps/miroflow-agent/src/llm/providers/__init__.py` | Registered `LiteLLMClient` in `__all__` |                                                                                                                  
  | `apps/miroflow-agent/src/llm/factory.py` | Added `"litellm"` to `SUPPORTED_PROVIDERS` and `client_creators` |                                                                                                    
  | `apps/miroflow-agent/pyproject.toml` | Added `litellm>=1.60.0,<2.0.0` |                                                                                                                                          
  | `tests/test_litellm_client.py` | 33 unit tests |                                                                                                                                                                 
                                                                                                                                                                                                                     
  ---                                                                                                                                                                                                                
                                                                                                                                                                                                                     
  ## Usage        

  ### Hydra Config

  ```yaml
  llm:
    provider: litellm
    model_name: anthropic/claude-3-haiku  # any LiteLLM model string
    api_key: ${oc.env:ANTHROPIC_API_KEY,null}  # optional, litellm reads env vars                                                                                                                                    
    temperature: 0.0                                                                                                                                                                                                 
    max_tokens: 4096                                                                                                                                                                                                 
                                                                                                                                                                                                                     
  Switching Providers: Just Change the Model String                                                                                                                                                                  
                  
  # OpenAI                                                                                                                                                                                                           
  llm:
    provider: litellm                                                                                                                                                                                                
    model_name: openai/gpt-4o

  # Anthropic                                                                                                                                                                                                        
  llm:
    provider: litellm                                                                                                                                                                                                
    model_name: anthropic/claude-3-haiku

  # AWS Bedrock
  llm:
    provider: litellm
    model_name: bedrock/anthropic.claude-v2

  # Groq                                                                                                                                                                                                             
  llm:
    provider: litellm                                                                                                                                                                                                
    model_name: groq/llama3-70b-8192

  # Local Ollama
  llm:
    provider: litellm
    model_name: ollama/llama3
 ```
                                                                                                                                                                                                                     
  Provider API keys are read from standard environment variables automatically (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.).                                                                                            
                                                                                                                                                                                                                     
  Any of the https://docs.litellm.ai/docs/providers works.                                                                                                                                                           
                  
  ### Programmatic Usage                                                                                                                                                                                                 
 ```python                 
  from src.llm.factory import ClientFactory
                                                                                                                                                                                                                     
  client = ClientFactory(
      task_id="task_001",                                                                                                                                                                                            
      cfg=cfg,  # Hydra config with llm.provider="litellm"                                                                                                                                                           
      task_log=task_log,                                                                                                                                                                                             
  )                                                                                                                                                                                                                  
                                                                                                                                                                                                                     
  response, history = await client.create_message(                                                                                                                                                                   
      system_prompt="You are helpful.",
      message_history=[{"role": "user", "content": "What is 2+2?"}],                                                                                                                                                 
      tool_definitions=[],                                                                                                                                                                                           
  )
```                                                                                                                                                                                                                     
  ---             
  ## Testing
         
  ### Unit Tests (33/33 Passing)
```                                                                                                                                                                                                                     
  tests/test_litellm_client.py::TestSyncProxy::test_returns_response_content PASSED
  tests/test_litellm_client.py::TestSyncProxy::test_calls_litellm_completion PASSED                                                                                                                                  
  tests/test_litellm_client.py::TestSyncProxyParams::test_drop_params_always_true PASSED
  tests/test_litellm_client.py::TestSyncProxyParams::test_model_forwarded PASSED                                                                                                                                     
  tests/test_litellm_client.py::TestSyncProxyParams::test_messages_forwarded PASSED                                                                                                                                  
  tests/test_litellm_client.py::TestSyncProxyParams::test_temperature_forwarded PASSED
  tests/test_litellm_client.py::TestSyncProxyParams::test_max_tokens_forwarded PASSED                                                                                                                                
  tests/test_litellm_client.py::TestSyncProxyParams::test_top_p_forwarded PASSED
  tests/test_litellm_client.py::TestSyncProxyParams::test_stream_forwarded PASSED                                                                                                                                    
  tests/test_litellm_client.py::TestSyncProxyParams::test_extra_body_forwarded PASSED
  tests/test_litellm_client.py::TestSyncProxyParams::test_user_cannot_override_drop_params PASSED                                                                                                                    
  tests/test_litellm_client.py::TestAsyncProxy::test_returns_response_content PASSED
  tests/test_litellm_client.py::TestAsyncProxy::test_drop_params_true PASSED                                                                                                                                         
  tests/test_litellm_client.py::TestFactoryRegistration::test_litellm_in_supported_providers PASSED
  tests/test_litellm_client.py::TestFactoryRegistration::test_litellm_in_providers_init_all PASSED                                                                                                                   
  tests/test_litellm_client.py::TestFactoryRegistration::test_litellm_importable_from_providers PASSED                                                                                                               
  tests/test_litellm_client.py::TestFactoryRegistration::test_litellm_client_extends_openai_client PASSED                                                                                                            
  tests/test_litellm_client.py::TestFactoryRegistration::test_unsupported_provider_raises PASSED                                                                                                                     
  tests/test_litellm_client.py::TestCreateClient::test_returns_proxy_instance PASSED                                                                                                                                 
  tests/test_litellm_client.py::TestCreateClient::test_sync_mode_uses_sync_completions PASSED
  tests/test_litellm_client.py::TestCreateClient::test_async_mode_uses_async_completions PASSED                                                                                                                      
  tests/test_litellm_client.py::TestCreateClient::test_proxy_has_chat_attribute PASSED
  tests/test_litellm_client.py::TestResponseFormat::test_response_has_choices PASSED                                                                                                                                 
  tests/test_litellm_client.py::TestResponseFormat::test_response_has_usage PASSED                                                                                                                                   
  tests/test_litellm_client.py::TestResponseFormat::test_response_has_finish_reason PASSED
  tests/test_litellm_client.py::TestResponseFormat::test_response_message_has_content_and_role PASSED                                                                                                                
  tests/test_litellm_client.py::TestMultiProviderModels::test_model_string_forwarded_to_litellm[openai/gpt-4o] PASSED
  tests/test_litellm_client.py::TestMultiProviderModels::test_model_string_forwarded_to_litellm[anthropic/claude-3-haiku] PASSED                                                                                     
  tests/test_litellm_client.py::TestMultiProviderModels::test_model_string_forwarded_to_litellm[bedrock/anthropic.claude-v2] PASSED                                                                                  
  tests/test_litellm_client.py::TestMultiProviderModels::test_model_string_forwarded_to_litellm[vertex_ai/gemini-pro] PASSED                                                                                         
  tests/test_litellm_client.py::TestMultiProviderModels::test_model_string_forwarded_to_litellm[groq/llama3-70b-8192] PASSED                                                                                         
  tests/test_litellm_client.py::TestMultiProviderModels::test_model_string_forwarded_to_litellm[ollama/llama3] PASSED                                                                                                
  tests/test_litellm_client.py::TestMultiProviderModels::test_model_string_forwarded_to_litellm[azure/gpt-4o] PASSED                                                                                                 
  ============================== 33 passed in 1.17s ==============================                                                                                                                                   
  ```                                                                                                                                                                                                                   
  ### E2E Tests(Azure AI Foundry, Claude Sonnet via LiteLLM)                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                     
  Model: azure_ai/claude-sonnet-4-6                                                                                                                                                                                  
                                                                                                                                                                                                                     
  --- E2E 1: Basic completion ---                                                                                                                                                                                    
  Prompt: "What is 2+2? Reply with just the number."
  Response: "4"                                                                                                                                                                                                      
  Finish reason: stop  
  Tokens: prompt=20, completion=5

  --- E2E 2: Multi-turn conversation ---                                                                                                                                                                             
  Messages:
    system: "You are a math tutor. Be very brief."                                                                                                                                                                   
    user: "What is 10 * 5?"                                                                                                                                                                                          
    assistant: "50"
    user: "Divide that by 2"                                                                                                                                                                                         
  Response: "25"                                                                                                                                                                                                     
   
  --- E2E 3: Factory registration ---                                                                                                                                                                                
  "litellm" in SUPPORTED_PROVIDERS: True
  LiteLLMClient extends OpenAIClient: True

  --- E2E 4: Error handling (invalid model) ---                                                                                                                                                                      
  Model: nonexistent/bad-model
  Caught expected error: BadRequestError                                                                                                                                                                             
  "LLM Provider NOT provided. Pass in the LLM provider you are trying to call."

  ---                                                                                                                                                                                                                
  Risk / Compatibility
                                                                                                                                                                                                                     
  - Additive only, no existing provider code changed
  - LiteLLMClient extends OpenAIClient, inheriting all retry logic, token tracking, and response processing                                                                                                          
  - drop_params=True enforced by the proxy so provider-unsupported kwargs are silently dropped                                                                                                                       
  - LiteLLM lazily imported inside proxy methods, users who don't use this provider are unaffected                                                                                                                   
